### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,15 @@
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-configuration/about-code-owners
+#
+# Last matching pattern wins. Keep the most specific paths at the bottom so
+# the explicit re-statements below cannot be silently overridden by a future
+# broader matcher inserted above them.
+
+# Global default — Adrian as sole maintainer.
+*                                                         @a7asoft
+
+# EMV / TLV / PCI-sensitive paths — explicit re-statement so future broader
+# matchers cannot bypass owner review on the security-critical surface.
+/shared/src/commonMain/kotlin/io/github/a7asoft/nfcemv/   @a7asoft
+/docs/threat-model.md                                     @a7asoft
+/CLAUDE.md                                                @a7asoft
+/.github/CODEOWNERS                                       @a7asoft


### PR DESCRIPTION
## Summary
- Adds `.github/CODEOWNERS` declaring `@a7asoft` as sole maintainer.
- Explicit re-statement on PCI/EMV-sensitive paths (commonMain `nfcemv/` tree, `docs/threat-model.md`, `CLAUDE.md`, the CODEOWNERS file itself) so a future broader matcher inserted above cannot silently bypass owner review.

## Notes
- GitHub reads CODEOWNERS from the PR's base branch, so it must reach both `develop` and `main`. This PR lands it on `develop`; the next release PR (`develop` → `main`) carries it over.
- Branch protection rules on `develop` / `main` are unchanged by this PR — to actually enforce ownership, enable "Require review from Code Owners" in repo Settings → Branches.

## Test plan
- [x] CODEOWNERS validated by GitHub (no parse warnings on the PR page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)