### PR TITLE
fix(samples): drop deleted Greeting() reference

### DIFF
--- a/composeApp/src/androidMain/kotlin/io/github/a7asoft/App.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/a7asoft/App.kt
@@ -35,13 +35,12 @@ fun App() {
                 Text("Click me!")
             }
             AnimatedVisibility(showContent) {
-                val greeting = remember { Greeting().greet() }
                 Column(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
                     Image(painterResource(Res.drawable.compose_multiplatform), null)
-                    Text("Compose: $greeting")
+                    Text("nfc-emv-toolkit sample")
                 }
             }
         }

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import Shared
 
 struct ContentView: View {
     @State private var showContent = false
@@ -16,7 +15,7 @@ struct ContentView: View {
                     Image(systemName: "swift")
                         .font(.system(size: 200))
                         .foregroundColor(.accentColor)
-                    Text("SwiftUI: \(Greeting().greet())")
+                    Text("nfc-emv-toolkit sample")
                 }
                 .transition(.move(edge: .top).combined(with: .opacity))
             }


### PR DESCRIPTION
## Summary
- PR #13 deleted KMP scaffolding `Greeting` / `Platform` from `shared/commonMain` but the sample apps still referenced `Greeting().greet()`.
- `composeApp:assembleDebug` is now failing on the release PR (#15) CI; iOS would follow when built.
- Replaces both call sites with a static `"nfc-emv-toolkit sample"` label; drops the now-unused `import Shared` on iOS.

## Notes
- Samples remain placeholders. They get rewired to the real reader API in issues #5 / #8.
- Once merged to `develop`, release PR #15 auto-updates and CI should turn green.

## Test plan
- [x] `./gradlew :composeApp:assembleDebug` clean locally
- [ ] CI green on this PR
- [ ] CI green on PR #15 after this lands in `develop`

🤖 Generated with [Claude Code](https://claude.com/claude-code)