### PR TITLE
release: BER-TLV encoder (v0.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ All notable changes to this project will be documented here. The format follows 
 - `TlvDecoder.parse` (returns sealed result) and `TlvDecoder.parseOrThrow` (throws on first violation). Both honor the same option set.
 - 116 tests on `commonMain`: happy paths for primitive / constructed / nested, every error variant, EMV padding behavior, documented X.690 deviation cases (e.g. `9F02`, `BF0C`), 10,000-iteration deterministic fuzz, OOM-resistance regression with pinned `UnexpectedEof`, PCI-safety regressions for tags `5A` / `57` / `9F26` with exact-form `toString` assertions.
 
+### Added — BER-TLV encoder (#2)
+- `TlvEncoder.encode(node: Tlv): ByteArray` and `TlvEncoder.encode(nodes: List<Tlv>): ByteArray` — the only public surface, mirrors `TlvDecoder`.
+- DER-canonical output: definite length, minimal length octets. No options.
+- Two-pass exact-allocation strategy: one pass computes the size, second pass fills a single pre-allocated `ByteArray`. No intermediate buffers.
+- Tag bytes are preserved verbatim from the source `Tlv` tree, so EMV deviations like `9F02` and `BF0C` round-trip byte-for-byte at the tag level.
+- Defense in depth: hardcoded `MAX_DEPTH = 64` guard mirrors `TlvOptions.maxDepth` upper bound; trees deeper than that surface as `IllegalStateException`.
+- Round-trip invariant: for every input accepted by the decoder, `decode(encode(parsed.tlvs)) == parsed.tlvs`. Pinned by deterministic 5,000-iteration fuzz and a fixture suite (FCI Visa, Track2, ARQC, nested depth 3, multi-primitive).
+
 #### Removed before release
 - An earlier draft included a `rejectTrailingBytes` option intended to catch APDU responses passed in with SW1 SW2 still attached. Removed because at the BER-TLV layer `90 00` decodes as a valid empty primitive, not as trailing bytes — SW detection belongs to the transport layer.
 - Wizard-generated scaffold (`Greeting.kt`, `Platform.kt`, `SharedCommonTest.example`) cleaned up.

--- a/docs/recipes/parse-tlv.md
+++ b/docs/recipes/parse-tlv.md
@@ -111,3 +111,21 @@ val tlvs = TlvDecoder.parseOrThrow(data)
 - Interpreting EMV tags semantically (PAN, expiry, brand) — see future recipes once the `emv` and `extract` modules ship.
 - Building APDUs and chaining `61 xx` / `6C xx` responses — that's transport-layer concern.
 - Handling cards that return token PANs (`9F6B` Mastercard PayPass etc.) vs raw PANs (`5A`) — extraction module will handle that.
+
+## Re-emit a parsed tree
+
+If you need to forward the same TLV stream you decoded — for example, to a downstream service that expects raw EMV bytes — use `TlvEncoder`:
+
+```kotlin
+import io.github.a7asoft.nfcemv.tlv.*
+
+val parsed = TlvDecoder.parse(response)
+if (parsed is TlvParseResult.Ok) {
+    val reEmitted: ByteArray = TlvEncoder.encode(parsed.tlvs)
+    forwardToBackend(reEmitted)
+}
+```
+
+Output is always DER-canonical (minimal length, definite-only). If the original card response used non-minimal length octets (uncommon), the re-emitted bytes will be shorter but **semantically identical** — a second `TlvDecoder.parse` produces the same `Tlv` tree.
+
+> **PCI safety:** the encoder writes value bytes for sensitive tags (`5A`, `57`, `9F26`) into the output `ByteArray` as required to be useful — that is the encoder's job. The constraint is the same as for `Tlv.Primitive.copyValue()`: never log the result, never persist it, never send it anywhere except a typed extractor or a transport whose endpoint is itself PCI-scoped.

--- a/shared/README.md
+++ b/shared/README.md
@@ -6,7 +6,7 @@ Pure-Kotlin core for the nfc-emv-toolkit. Lives in `commonMain` and ships with n
 
 | Package | Purpose |
 |---------|---------|
-| `io.github.a7asoft.nfcemv.tlv` | BER-TLV decoder (this milestone) |
+| `io.github.a7asoft.nfcemv.tlv` | BER-TLV decoder + encoder (this milestone) |
 | `io.github.a7asoft.nfcemv.tlv.internal` | Reader cursor, tag/length/node decoders, padding skipper. Internal — do not depend on these symbols. |
 
 Future packages (later issues): `emv` (tag dictionary), `brand` (AID + BIN brand resolution), `extract` (PAN, Track2, expiry), `validation` (Luhn, format checks).
@@ -24,7 +24,7 @@ when (val result = TlvDecoder.parse(response)) {
 }
 
 fun printTlv(tlv: Tlv): Unit = when (tlv) {
-    is Tlv.Primitive   -> println("${tlv.tag}: ${tlv.value.size} bytes")
+    is Tlv.Primitive   -> println("${tlv.tag}: ${tlv.length} bytes")
     is Tlv.Constructed -> { println("${tlv.tag}: ${tlv.children.size} children"); tlv.children.forEach(::printTlv) }
 }
 ```
@@ -62,10 +62,11 @@ All variants implement `TlvError` and carry the byte offset where the problem wa
 |---------|-------|
 | `UnexpectedEof` | Input ended before a tag, length, or value finished |
 | `IndefiniteLengthForbidden` | Length octet was `0x80` (forbidden in EMV) |
-| `InvalidLengthOctet` | Length octet was reserved (`0x85`–`0xFF`) or value too large for `Int` |
+| `InvalidLengthOctet` | First length octet was reserved or unsupported (`0x85`–`0xFF`) |
+| `LengthOverflow` | Long-form length parsed structurally but decoded value exceeds `Int.MAX_VALUE` |
 | `IncompleteTag` | Multi-byte tag started but not terminated before EOF |
 | `TagTooLong` | Multi-byte tag exceeded `maxTagBytes` |
-| `NonMinimalTagEncoding` | Strict mode: first continuation byte was `0x80` (leading zero) |
+| `NonMinimalTagEncoding` | Strict mode: first continuation byte's seven low bits were all zero (`0x00` or `0x80`) per ISO/IEC 8825-1 §8.1.2.4.2(c) |
 | `NonMinimalLengthEncoding` | Strict mode: long-form length used more octets than necessary |
 | `ChildrenLengthMismatch` | Constructed value's children consumed a different number of bytes than declared |
 | `MaxDepthExceeded` | Constructed nesting exceeded `maxDepth` |
@@ -82,9 +83,27 @@ ISO/IEC 8825-1 §8.1.2.4 mandates that tag numbers ≤ 30 use the short single-b
 
 The X.690 leading-zero rule (first continuation byte ≠ `0x80`) **is** enforced in strict mode — that one is universal.
 
+## BER-TLV encoder — quickstart
+
+Re-emit a parsed `Tlv` tree (or a list of trees) as DER-canonical BER-TLV bytes:
+
+```kotlin
+import io.github.a7asoft.nfcemv.tlv.*
+
+val parsed = TlvDecoder.parse(response)
+if (parsed is TlvParseResult.Ok) {
+    val reEmitted: ByteArray = TlvEncoder.encode(parsed.tlvs)
+    forwardToBackend(reEmitted)
+}
+```
+
+The encoder takes no options. Output is always X.690 DER-canonical (definite length, minimal length octets). If the original card response used non-minimal length octets (uncommon), the re-emitted bytes will be shorter but **semantically identical** — a second `TlvDecoder.parse` produces the same `Tlv` tree.
+
+Defense-in-depth: a hardcoded `MAX_DEPTH = 64` guard fires `IllegalStateException` on caller-built trees that exceed it (the decoder's `TlvOptions.maxDepth` defaults to 16; the encoder's higher cap accommodates any tree the decoder accepts).
+
 ## Tests
 
-116 tests on `commonMain` cover happy paths, all error variants, the EMV padding behavior, the documented X.690 deviation, fuzz over 10,000 random buffers (strict + lenient), OOM-resistance regression, and PCI-safety regressions for tags `5A`, `57`, and `9F26`. Run with:
+179 tests on `commonMain` cover happy paths, all error variants, the EMV padding behavior, the documented X.690 deviation, fuzz over 10,000 random buffers (strict + lenient), OOM-resistance regression, PCI-safety regressions for tags `5A`, `57`, and `9F26`, encoder round-trip fixtures, 5,000-iteration encoder fuzz, encoder PCI-safety regressions. Run with:
 
 ```bash
 ./gradlew :shared:testDebugUnitTest

--- a/shared/src/commonMain/kotlin/io/github/a7asoft/nfcemv/tlv/Tlv.kt
+++ b/shared/src/commonMain/kotlin/io/github/a7asoft/nfcemv/tlv/Tlv.kt
@@ -40,6 +40,17 @@ public sealed interface Tlv {
         /** Returns a fresh defensive copy of the value bytes. */
         public fun copyValue(): ByteArray = storedValue.copyOf()
 
+        /**
+         * Copy this primitive's value bytes directly into [dst] starting at
+         * [offset]. The encoder uses this to avoid the double-copy that
+         * `copyValue()` + `copyInto` would produce. Returns the offset just
+         * past the last byte written.
+         */
+        internal fun writeValueInto(dst: ByteArray, offset: Int): Int {
+            storedValue.copyInto(dst, destinationOffset = offset)
+            return offset + storedValue.size
+        }
+
         override fun equals(other: Any?): Boolean {
             if (this === other) return true
             if (other !is Primitive) return false

--- a/shared/src/commonMain/kotlin/io/github/a7asoft/nfcemv/tlv/TlvEncoder.kt
+++ b/shared/src/commonMain/kotlin/io/github/a7asoft/nfcemv/tlv/TlvEncoder.kt
@@ -1,0 +1,49 @@
+package io.github.a7asoft.nfcemv.tlv
+
+import io.github.a7asoft.nfcemv.tlv.internal.encodedSize
+import io.github.a7asoft.nfcemv.tlv.internal.writeNode
+
+/**
+ * Public entry point for BER-TLV encoding.
+ *
+ * Output is always X.690 DER-canonical: definite length, minimal length
+ * octets. The encoder takes no options — there is no legitimate reason to
+ * emit non-minimal long-form length on a fresh stream. Tag bytes are
+ * preserved verbatim from the [Tlv] tree, so EMV deviations like `9F02`
+ * and `BF0C` round-trip byte-for-byte at the tag level.
+ *
+ * The encoder uses two passes over a pre-allocated [ByteArray]: first to
+ * compute the total size, second to fill the buffer. The second pass
+ * re-derives constructed-node lengths on the fly (the first pass's running
+ * subtotals are not memoized), so the work is roughly `O(n + n_constructed
+ * × children-per-constructed)` rather than strictly linear; for the
+ * EMV-shaped trees this library targets, both terms are small. Value bytes
+ * are written into [dst] in a single defensive copy via the `internal`
+ * [Tlv.Primitive] writer — no temporary value-bytes buffers exist anywhere
+ * in the encoder path.
+ *
+ * Defense in depth: a hardcoded `MAX_DEPTH = 64` guard mirrors the upper
+ * bound of `TlvOptions.maxDepth`, protecting against caller-constructed
+ * trees that bypassed the decoder.
+ */
+public object TlvEncoder {
+
+    /** Encode a single [Tlv] tree. */
+    public fun encode(node: Tlv): ByteArray {
+        val size = encodedSize(node)
+        val dst = ByteArray(size)
+        val end = writeNode(node, dst, offset = 0, depth = 0)
+        check(end == size) { "Encoder size mismatch: predicted=$size actual=$end" }
+        return dst
+    }
+
+    /** Encode a list of top-level [Tlv] nodes as a concatenated stream. */
+    public fun encode(nodes: List<Tlv>): ByteArray {
+        val total = nodes.sumOf { encodedSize(it) }
+        require(total >= 0) { "Total encoded size overflows Int" }
+        val dst = ByteArray(total)
+        val end = nodes.fold(0) { pos, node -> writeNode(node, dst, pos, depth = 0) }
+        check(end == total) { "Encoder size mismatch: predicted=$total actual=$end" }
+        return dst
+    }
+}

--- a/shared/src/commonMain/kotlin/io/github/a7asoft/nfcemv/tlv/internal/EncodedSize.kt
+++ b/shared/src/commonMain/kotlin/io/github/a7asoft/nfcemv/tlv/internal/EncodedSize.kt
@@ -1,0 +1,35 @@
+package io.github.a7asoft.nfcemv.tlv.internal
+
+import io.github.a7asoft.nfcemv.tlv.Tlv
+
+/**
+ * Compute the total number of bytes [node] will occupy when serialized as a
+ * BER-TLV stream in DER-canonical (minimal length) form.
+ *
+ * First pass of the encoder's two-pass strategy. Recursion is bounded by
+ * [MAX_DEPTH]; trees deeper than that surface as [IllegalStateException]
+ * mirroring the second-pass guard in [writeNode].
+ */
+internal fun encodedSize(node: Tlv): Int = encodedSizeAt(node, depth = 0)
+
+private fun encodedSizeAt(node: Tlv, depth: Int): Int {
+    check(depth <= MAX_DEPTH) { "TLV encode depth exceeds $MAX_DEPTH" }
+    return when (node) {
+        is Tlv.Primitive -> sizePrimitive(node)
+        is Tlv.Constructed -> sizeConstructed(node, depth)
+    }
+}
+
+private fun sizePrimitive(node: Tlv.Primitive): Int {
+    val size = node.tag.byteCount + lengthOctets(node.length) + node.length
+    require(size >= 0) { "Primitive encoded size overflows Int" }
+    return size
+}
+
+private fun sizeConstructed(node: Tlv.Constructed, depth: Int): Int {
+    val childrenSize = node.children.sumOf { encodedSizeAt(it, depth + 1) }
+    require(childrenSize >= 0) { "Constructed children size overflows Int" }
+    val total = node.tag.byteCount + lengthOctets(childrenSize) + childrenSize
+    require(total >= 0) { "Constructed encoded size overflows Int" }
+    return total
+}

--- a/shared/src/commonMain/kotlin/io/github/a7asoft/nfcemv/tlv/internal/EncoderConstants.kt
+++ b/shared/src/commonMain/kotlin/io/github/a7asoft/nfcemv/tlv/internal/EncoderConstants.kt
@@ -1,0 +1,11 @@
+package io.github.a7asoft.nfcemv.tlv.internal
+
+/**
+ * Hard cap on TLV nesting depth honored by both encoder passes
+ * ([encodedSize] and [writeNode]).
+ *
+ * Mirrors the upper bound of `TlvOptions.maxDepth`, so any tree the decoder
+ * accepts can also be re-emitted; caller-built trees that exceed this surface
+ * as `IllegalStateException` instead of `StackOverflowError` from either pass.
+ */
+internal const val MAX_DEPTH: Int = 64

--- a/shared/src/commonMain/kotlin/io/github/a7asoft/nfcemv/tlv/internal/LengthWriter.kt
+++ b/shared/src/commonMain/kotlin/io/github/a7asoft/nfcemv/tlv/internal/LengthWriter.kt
@@ -1,0 +1,44 @@
+package io.github.a7asoft.nfcemv.tlv.internal
+
+private const val SHORT_FORM_MAX = 0x7F
+private const val LONG_FORM_BASE = 0x80
+
+/**
+ * Number of octets required to encode [value] as a BER-TLV length field per
+ * ISO/IEC 8825-1 §8.1.3 in the minimal (DER-canonical) form.
+ *
+ * Short form (1 octet) covers `0..127`; long form covers `128..Int.MAX_VALUE`
+ * with `1 + n` octets, where `n` is the minimum number of big-endian octets
+ * needed to represent the value.
+ */
+internal fun lengthOctets(value: Int): Int {
+    require(value >= 0) { "Length must be non-negative: $value" }
+    if (value <= SHORT_FORM_MAX) return 1
+    return 1 + significantOctets(value)
+}
+
+/**
+ * Write the BER-TLV length field for [value] into [dst] starting at [offset]
+ * in DER-canonical minimal form. Returns the offset just past the last byte
+ * written.
+ */
+internal fun writeLength(value: Int, dst: ByteArray, offset: Int): Int {
+    require(value >= 0) { "Length must be non-negative: $value" }
+    require(offset + lengthOctets(value) <= dst.size) {
+        "Destination too small: offset=$offset, needed=${lengthOctets(value)}, capacity=${dst.size}"
+    }
+    if (value <= SHORT_FORM_MAX) {
+        dst[offset] = value.toByte()
+        return offset + 1
+    }
+    val octets = significantOctets(value)
+    dst[offset] = (LONG_FORM_BASE or octets).toByte()
+    for (i in 0 until octets) {
+        val shift = (octets - 1 - i) * 8
+        dst[offset + 1 + i] = ((value ushr shift) and 0xFF).toByte()
+    }
+    return offset + 1 + octets
+}
+
+private fun significantOctets(value: Int): Int =
+    (Int.SIZE_BITS - value.countLeadingZeroBits() + 7) / 8

--- a/shared/src/commonMain/kotlin/io/github/a7asoft/nfcemv/tlv/internal/NodeWriter.kt
+++ b/shared/src/commonMain/kotlin/io/github/a7asoft/nfcemv/tlv/internal/NodeWriter.kt
@@ -1,0 +1,49 @@
+package io.github.a7asoft.nfcemv.tlv.internal
+
+import io.github.a7asoft.nfcemv.tlv.Tlv
+
+/**
+ * Write [node] into [dst] starting at [offset] in DER-canonical BER-TLV form.
+ * Returns the offset just past the last byte written.
+ *
+ * Two preconditions on the input tree (defense in depth — the decoder
+ * already enforces both on parsed inputs, but caller-built trees can bypass
+ * the decoder entirely):
+ *
+ * - [depth] ≤ [MAX_DEPTH]: rejects pathologically nested trees as
+ *   [IllegalStateException] before they can stack-overflow the recursion.
+ * - The node's tag P/C bit must match the encoding form ([Tlv.Primitive] ⇒
+ *   primitive bit; [Tlv.Constructed] ⇒ constructed bit) per ISO/IEC 8825-1
+ *   §8.1.2.5; mismatches surface as [IllegalArgumentException].
+ */
+internal fun writeNode(node: Tlv, dst: ByteArray, offset: Int, depth: Int): Int {
+    check(depth <= MAX_DEPTH) { "TLV encode depth exceeds $MAX_DEPTH" }
+    require(node.matchesPCBit()) {
+        "Tlv ${node::class.simpleName} tag P/C bit contradicts encoding form (ISO/IEC 8825-1 §8.1.2.5)"
+    }
+    val tagBytes = node.tag.bytes
+    tagBytes.copyInto(dst, offset)
+    val afterTag = offset + tagBytes.size
+    return when (node) {
+        is Tlv.Primitive -> writePrimitiveBody(node, dst, afterTag)
+        is Tlv.Constructed -> writeConstructedBody(node, dst, afterTag, depth)
+    }
+}
+
+private fun Tlv.matchesPCBit(): Boolean = when (this) {
+    is Tlv.Primitive -> tag.isPrimitive
+    is Tlv.Constructed -> tag.isConstructed
+}
+
+private fun writePrimitiveBody(node: Tlv.Primitive, dst: ByteArray, offset: Int): Int {
+    val afterLength = writeLength(node.length, dst, offset)
+    return node.writeValueInto(dst, afterLength)
+}
+
+private fun writeConstructedBody(node: Tlv.Constructed, dst: ByteArray, offset: Int, depth: Int): Int {
+    val childrenSize = node.children.sumOf { encodedSize(it) }
+    val afterLength = writeLength(childrenSize, dst, offset)
+    return node.children.fold(afterLength) { pos, child ->
+        writeNode(child, dst, pos, depth + 1)
+    }
+}

--- a/shared/src/commonTest/kotlin/io/github/a7asoft/nfcemv/tlv/TlvEncoderFuzzTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/a7asoft/nfcemv/tlv/TlvEncoderFuzzTest.kt
@@ -1,0 +1,47 @@
+package io.github.a7asoft.nfcemv.tlv
+
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+/**
+ * Property: for every byte buffer the decoder accepts, encoding the
+ * resulting tree and decoding the encoded output MUST yield an equal tree.
+ *
+ * Strategy: run 20,000 deterministic random buffers through the decoder; for
+ * each buffer that produces an `Ok`, assert the round-trip property. Inputs
+ * that produce an `Err` are skipped — they are not the encoder's domain.
+ */
+class TlvEncoderFuzzTest {
+
+    @Test
+    fun `every decoder-accepted input round-trips through encode and decode`() {
+        val rng = Random(SEED)
+        var roundTripped = 0
+        repeat(ITERATIONS) {
+            val length = rng.nextInt(0, MAX_INPUT_BYTES + 1)
+            val data = ByteArray(length).also { rng.nextBytes(it) }
+            val parsed = TlvDecoder.parse(data)
+            if (parsed is TlvParseResult.Ok) {
+                val encoded = TlvEncoder.encode(parsed.tlvs)
+                val reparsed = assertIs<TlvParseResult.Ok>(TlvDecoder.parse(encoded))
+                assertEquals(parsed.tlvs, reparsed.tlvs)
+                roundTripped++
+            }
+        }
+        // Sanity check that the seed actually produces some accepted inputs;
+        // otherwise this test would silently pass while exercising nothing.
+        kotlin.test.assertTrue(
+            roundTripped >= MIN_ROUND_TRIPS,
+            "expected at least $MIN_ROUND_TRIPS round-trips, exercised $roundTripped",
+        )
+    }
+
+    private companion object {
+        const val SEED: Long = 0x454E5201L
+        const val ITERATIONS: Int = 20_000
+        const val MAX_INPUT_BYTES: Int = 256
+        const val MIN_ROUND_TRIPS: Int = 50
+    }
+}

--- a/shared/src/commonTest/kotlin/io/github/a7asoft/nfcemv/tlv/TlvEncoderPciSafetyTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/a7asoft/nfcemv/tlv/TlvEncoderPciSafetyTest.kt
@@ -1,0 +1,109 @@
+package io.github.a7asoft.nfcemv.tlv
+
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+
+/**
+ * The encoder MUST emit exactly the bytes the spec requires (otherwise it
+ * is broken), but it must NOT introduce any new surface that turns a
+ * sensitive `Tlv.Primitive` into a stringified value byte. The Primitive's
+ * `toString()` already masks (PR #13); this suite pins that the encoder
+ * does not regress that contract through any side channel.
+ *
+ * If any of these tests start to fail, do NOT relax them. Find the leak
+ * (per CLAUDE.md §6.1).
+ */
+class TlvEncoderPciSafetyTest {
+
+    @Test
+    fun `encoding tag 5A produces correct bytes`() {
+        // 5A 08 41 11 11 11 11 11 11 11 — fake test PAN
+        val pan = byteArrayOf(0x41, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11)
+        val node = Tlv.Primitive(Tag.fromHex("5A"), pan)
+        val out = TlvEncoder.encode(node)
+        assertContentEquals(byteArrayOf(0x5A, 0x08) + pan, out)
+    }
+
+    @Test
+    fun `Primitive toString for tag 5A stays masked after encode`() {
+        val pan = byteArrayOf(0x41, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11)
+        val node = Tlv.Primitive(Tag.fromHex("5A"), pan)
+        TlvEncoder.encode(node)
+        assertEquals("Primitive(tag=5A, length=8)", node.toString())
+    }
+
+    @Test
+    fun `encoder IllegalStateException message does not embed value bytes`() {
+        // Build a depth-exhausted tree wrapping a fake PAN leaf.
+        val pan = byteArrayOf(0x41, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11)
+        var node: Tlv = Tlv.Primitive(Tag.fromHex("5A"), pan)
+        repeat(70) {
+            node = Tlv.Constructed(Tag.fromHex("70"), listOf(node))
+        }
+        val ex = assertFailsWith<IllegalStateException> { TlvEncoder.encode(node) }
+        val msg = ex.message ?: ""
+        assertFalse("0x41" in msg, "byte leaked: $msg")
+        assertFalse("0x11" in msg, "byte leaked: $msg")
+        assertFalse("4111" in msg, "concatenated bytes leaked: $msg")
+    }
+
+    @Test
+    fun `encoder does not retain a reference to the input value bytes`() {
+        // Mutating the original array after construction must not affect
+        // the encoded output (defensive copy contract on Tlv.Primitive).
+        val source = byteArrayOf(0x41, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11)
+        val node = Tlv.Primitive(Tag.fromHex("5A"), source)
+        source[0] = 0x00
+        val out = TlvEncoder.encode(node)
+        assertEquals(0x41.toByte(), out[2])
+    }
+
+    @Test
+    fun `encoding tag 57 produces correct bytes`() {
+        // 57 0A 41 11 11 11 11 11 11 11 D2 80 — fake Track2
+        val track2 = byteArrayOf(
+            0x41, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0xD2.toByte(), 0x80.toByte(),
+        )
+        val node = Tlv.Primitive(Tag.fromHex("57"), track2)
+        val out = TlvEncoder.encode(node)
+        assertContentEquals(byteArrayOf(0x57, 0x0A) + track2, out)
+    }
+
+    @Test
+    fun `Primitive toString for tag 57 stays masked after encode`() {
+        val node = Tlv.Primitive(
+            Tag.fromHex("57"),
+            byteArrayOf(0x41, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0xD2.toByte(), 0x80.toByte()),
+        )
+        TlvEncoder.encode(node)
+        assertEquals("Primitive(tag=57, length=10)", node.toString())
+    }
+
+    @Test
+    fun `encoding tag 9F26 produces correct bytes`() {
+        // 9F 26 08 DE AD BE EF CA FE BA BE — fake ARQC
+        val arqc = byteArrayOf(
+            0xDE.toByte(), 0xAD.toByte(), 0xBE.toByte(), 0xEF.toByte(),
+            0xCA.toByte(), 0xFE.toByte(), 0xBA.toByte(), 0xBE.toByte(),
+        )
+        val node = Tlv.Primitive(Tag.fromHex("9F26"), arqc)
+        val out = TlvEncoder.encode(node)
+        assertContentEquals(byteArrayOf(0x9F.toByte(), 0x26, 0x08) + arqc, out)
+    }
+
+    @Test
+    fun `Primitive toString for tag 9F26 stays masked after encode`() {
+        val node = Tlv.Primitive(
+            Tag.fromHex("9F26"),
+            byteArrayOf(
+                0xDE.toByte(), 0xAD.toByte(), 0xBE.toByte(), 0xEF.toByte(),
+                0xCA.toByte(), 0xFE.toByte(), 0xBA.toByte(), 0xBE.toByte(),
+            ),
+        )
+        TlvEncoder.encode(node)
+        assertEquals("Primitive(tag=9F26, length=8)", node.toString())
+    }
+}

--- a/shared/src/commonTest/kotlin/io/github/a7asoft/nfcemv/tlv/TlvEncoderRoundTripTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/a7asoft/nfcemv/tlv/TlvEncoderRoundTripTest.kt
@@ -1,0 +1,110 @@
+package io.github.a7asoft.nfcemv.tlv
+
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+/**
+ * Round-trip invariant per issue #2: for every input the decoder accepts
+ * (and produces a `Tlv` tree from), encoding that tree and decoding the
+ * result MUST yield an equal tree. Byte-equality of the encoded form vs the
+ * original input is NOT guaranteed (the decoder accepts non-minimal length
+ * in lenient mode; the encoder always emits minimal length), but semantic
+ * equality of the `Tlv` tree is.
+ */
+class TlvEncoderRoundTripTest {
+
+    @Test
+    fun `FCI Visa response round-trips through encode and decode`() {
+        // 6F 16
+        //   84 07 A0 00 00 00 03 10 10
+        //   A5 0B
+        //     50 06 56 49 53 41 30 31
+        //     87 01 01
+        val input = byteArrayOf(
+            0x6F, 0x16,
+            0x84.toByte(), 0x07, 0xA0.toByte(), 0x00, 0x00, 0x00, 0x03, 0x10, 0x10,
+            0xA5.toByte(), 0x0B,
+            0x50, 0x06, 0x56, 0x49, 0x53, 0x41, 0x30, 0x31,
+            0x87.toByte(), 0x01, 0x01,
+        )
+        roundTrip(input)
+    }
+
+    @Test
+    fun `Track2 response round-trips`() {
+        val input = byteArrayOf(
+            0x57, 0x0A,
+            0x41, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0xD2.toByte(), 0x80.toByte(),
+        )
+        roundTrip(input)
+    }
+
+    @Test
+    fun `ARQC response round-trips`() {
+        val input = byteArrayOf(
+            0x9F.toByte(), 0x26, 0x08,
+            0xDE.toByte(), 0xAD.toByte(), 0xBE.toByte(), 0xEF.toByte(),
+            0xCA.toByte(), 0xFE.toByte(), 0xBA.toByte(), 0xBE.toByte(),
+        )
+        roundTrip(input)
+    }
+
+    @Test
+    fun `nested constructed depth 3 round-trips`() {
+        val input = byteArrayOf(
+            0x70, 0x08,
+            0xA5.toByte(), 0x06,
+            0xA6.toByte(), 0x04,
+            0x57, 0x02, 0x10, 0x20,
+        )
+        roundTrip(input)
+    }
+
+    @Test
+    fun `multiple top-level primitives round-trip as a list`() {
+        val input = byteArrayOf(0x57, 0x01, 0x10, 0x5A, 0x01, 0x20)
+        roundTrip(input)
+    }
+
+    @Test
+    fun `encoded output of a minimal-length input is byte-equal to the input`() {
+        // When the input is already DER-canonical (which all the fixtures
+        // above are), encode(decode(x)) MUST equal x byte-for-byte.
+        val input = byteArrayOf(
+            0x6F, 0x16,
+            0x84.toByte(), 0x07, 0xA0.toByte(), 0x00, 0x00, 0x00, 0x03, 0x10, 0x10,
+            0xA5.toByte(), 0x0B,
+            0x50, 0x06, 0x56, 0x49, 0x53, 0x41, 0x30, 0x31,
+            0x87.toByte(), 0x01, 0x01,
+        )
+        val tree = assertIs<TlvParseResult.Ok>(TlvDecoder.parse(input)).tlvs.single()
+        val encoded = TlvEncoder.encode(tree)
+        assertContentEquals(input, encoded)
+    }
+
+    @Test
+    fun `non-minimal-length input under lenient strictness re-emits as shorter byte-canonical form`() {
+        // Input uses 0x81 0x05 long-form length (non-minimal — 5 fits in short form).
+        // Strict mode rejects this; lenient accepts. Encoder always emits minimal,
+        // so the re-emitted bytes are exactly one byte shorter (0x05 vs 0x81 0x05)
+        // but the parsed Tlv tree is identical.
+        val nonMinimal = byteArrayOf(0x57, 0x81.toByte(), 0x05, 0x10, 0x20, 0x30, 0x40, 0x50)
+        val parsed = assertIs<TlvParseResult.Ok>(
+            TlvDecoder.parse(nonMinimal, TlvOptions(strictness = Strictness.Lenient)),
+        )
+        val encoded = TlvEncoder.encode(parsed.tlvs)
+        assertContentEquals(byteArrayOf(0x57, 0x05, 0x10, 0x20, 0x30, 0x40, 0x50), encoded)
+        assertEquals(nonMinimal.size - 1, encoded.size)
+        val reparsed = assertIs<TlvParseResult.Ok>(TlvDecoder.parse(encoded))
+        assertEquals(parsed.tlvs, reparsed.tlvs)
+    }
+
+    private fun roundTrip(input: ByteArray) {
+        val firstParse = assertIs<TlvParseResult.Ok>(TlvDecoder.parse(input))
+        val encoded = TlvEncoder.encode(firstParse.tlvs)
+        val secondParse = assertIs<TlvParseResult.Ok>(TlvDecoder.parse(encoded))
+        assertEquals(firstParse.tlvs, secondParse.tlvs)
+    }
+}

--- a/shared/src/commonTest/kotlin/io/github/a7asoft/nfcemv/tlv/TlvEncoderTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/a7asoft/nfcemv/tlv/TlvEncoderTest.kt
@@ -1,0 +1,99 @@
+package io.github.a7asoft.nfcemv.tlv
+
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class TlvEncoderTest {
+
+    @Test
+    fun `encodes a single primitive`() {
+        // 57 02 10 20
+        val node = Tlv.Primitive(Tag.fromHex("57"), byteArrayOf(0x10, 0x20))
+        val out = TlvEncoder.encode(node)
+        assertContentEquals(byteArrayOf(0x57, 0x02, 0x10, 0x20), out)
+    }
+
+    @Test
+    fun `encodes an empty primitive`() {
+        // 5A 00
+        val node = Tlv.Primitive(Tag.fromHex("5A"), ByteArray(0))
+        val out = TlvEncoder.encode(node)
+        assertContentEquals(byteArrayOf(0x5A, 0x00), out)
+    }
+
+    @Test
+    fun `encodes a constructed node with a single child`() {
+        // 70 04 57 02 10 20
+        val inner = Tlv.Primitive(Tag.fromHex("57"), byteArrayOf(0x10, 0x20))
+        val outer = Tlv.Constructed(Tag.fromHex("70"), listOf(inner))
+        val out = TlvEncoder.encode(outer)
+        assertContentEquals(byteArrayOf(0x70, 0x04, 0x57, 0x02, 0x10, 0x20), out)
+    }
+
+    @Test
+    fun `encodes EMV multi-byte tag 9F02 preserving raw bytes`() {
+        val node = Tlv.Primitive(Tag.fromHex("9F02"), byteArrayOf(0x00, 0x00, 0x00, 0x00, 0x01, 0x00))
+        val out = TlvEncoder.encode(node)
+        assertEquals(0x9F.toByte(), out[0])
+        assertEquals(0x02.toByte(), out[1])
+        assertEquals(0x06.toByte(), out[2])
+    }
+
+    @Test
+    fun `encodes EMV multi-byte tag BF0C as a constructed node preserving raw tag bytes`() {
+        // BF0C is a 2-byte tag (class 10 application, P/C 1 constructed, tag number 12 in long form).
+        // Round-trip a small constructed tree with one primitive child.
+        // Expected wire bytes: BF 0C 03 | 9F 36 00
+        // (BF0C constructed, length 3, child = 9F36 ATC primitive, length 0)
+        val child = Tlv.Primitive(Tag.fromHex("9F36"), ByteArray(0))
+        val node = Tlv.Constructed(Tag.fromHex("BF0C"), listOf(child))
+        val out = TlvEncoder.encode(node)
+        assertContentEquals(
+            byteArrayOf(0xBF.toByte(), 0x0C, 0x03, 0x9F.toByte(), 0x36, 0x00),
+            out,
+        )
+    }
+
+    @Test
+    fun `rejects depth-exhausted trees with IllegalStateException`() {
+        var node: Tlv = Tlv.Primitive(Tag.fromHex("57"), ByteArray(0))
+        repeat(70) {
+            node = Tlv.Constructed(Tag.fromHex("70"), listOf(node))
+        }
+        assertFailsWith<IllegalStateException> { TlvEncoder.encode(node) }
+    }
+
+    @Test
+    fun `encodes an empty list as an empty ByteArray`() {
+        val out = TlvEncoder.encode(emptyList())
+        assertEquals(0, out.size)
+    }
+
+    @Test
+    fun `encodes multiple top-level primitives in source order`() {
+        val a = Tlv.Primitive(Tag.fromHex("57"), byteArrayOf(0x10))
+        val b = Tlv.Primitive(Tag.fromHex("5A"), byteArrayOf(0x20))
+        val out = TlvEncoder.encode(listOf(a, b))
+        assertContentEquals(
+            byteArrayOf(0x57, 0x01, 0x10, 0x5A, 0x01, 0x20),
+            out,
+        )
+    }
+
+    @Test
+    fun `single-element list overload matches single-node overload`() {
+        val node = Tlv.Primitive(Tag.fromHex("57"), byteArrayOf(0x10, 0x20))
+        assertContentEquals(TlvEncoder.encode(node), TlvEncoder.encode(listOf(node)))
+    }
+
+    @Test
+    fun `encode list overload rejects depth-exhausted trees with IllegalStateException`() {
+        var node: Tlv = Tlv.Primitive(Tag.fromHex("57"), ByteArray(0))
+        repeat(70) {
+            node = Tlv.Constructed(Tag.fromHex("70"), listOf(node))
+        }
+        assertFailsWith<IllegalStateException> { TlvEncoder.encode(listOf(node)) }
+    }
+}

--- a/shared/src/commonTest/kotlin/io/github/a7asoft/nfcemv/tlv/TlvTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/a7asoft/nfcemv/tlv/TlvTest.kt
@@ -68,6 +68,29 @@ class TlvTest {
     }
 
     @Test
+    fun `Primitive writeValueInto copies bytes directly into the destination`() {
+        val node = Tlv.Primitive(Tag.fromHex("5A"), byteArrayOf(0x10, 0x20, 0x30))
+        val dst = ByteArray(5)
+        dst[0] = 0xAA.toByte()
+        dst[4] = 0xBB.toByte()
+        val end = node.writeValueInto(dst, offset = 1)
+        assertEquals(4, end)
+        assertContentEquals(
+            byteArrayOf(0xAA.toByte(), 0x10, 0x20, 0x30, 0xBB.toByte()),
+            dst,
+        )
+    }
+
+    @Test
+    fun `Primitive writeValueInto does not expose the stored array`() {
+        val node = Tlv.Primitive(Tag.fromHex("5A"), byteArrayOf(0x10, 0x20, 0x30))
+        val dst = ByteArray(3)
+        node.writeValueInto(dst, offset = 0)
+        dst[0] = 0x00
+        assertEquals(0x10.toByte(), node.copyValue()[0])
+    }
+
+    @Test
     fun `constructed toString reports child count`() {
         val tlv = Tlv.Constructed(
             Tag.fromHex("70"),

--- a/shared/src/commonTest/kotlin/io/github/a7asoft/nfcemv/tlv/internal/EncodedSizeTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/a7asoft/nfcemv/tlv/internal/EncodedSizeTest.kt
@@ -1,0 +1,77 @@
+package io.github.a7asoft.nfcemv.tlv.internal
+
+import io.github.a7asoft.nfcemv.tlv.Tag
+import io.github.a7asoft.nfcemv.tlv.Tlv
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class EncodedSizeTest {
+
+    @Test
+    fun `primitive size is tag bytes plus length octets plus value bytes`() {
+        // tag 5A (1 byte) + length 0x08 (1 byte) + 8 value bytes = 10
+        val node = Tlv.Primitive(Tag.fromHex("5A"), ByteArray(8))
+        assertEquals(10, encodedSize(node))
+    }
+
+    @Test
+    fun `primitive size accounts for multi-byte tag`() {
+        // tag 9F02 (2 bytes) + length 0x06 (1 byte) + 6 value bytes = 9
+        val node = Tlv.Primitive(Tag.fromHex("9F02"), ByteArray(6))
+        assertEquals(9, encodedSize(node))
+    }
+
+    @Test
+    fun `primitive size accounts for long-form length`() {
+        // tag 5A (1) + length 0x81 0x80 (2) + 128 value bytes = 131
+        val node = Tlv.Primitive(Tag.fromHex("5A"), ByteArray(0x80))
+        assertEquals(131, encodedSize(node))
+    }
+
+    @Test
+    fun `empty constructed has size tag plus length 0`() {
+        // tag 70 (1) + length 0x00 (1) + no children = 2
+        val node = Tlv.Constructed(Tag.fromHex("70"), emptyList())
+        assertEquals(2, encodedSize(node))
+    }
+
+    @Test
+    fun `constructed with one primitive child sums correctly`() {
+        // outer 70 (1) + length 0x04 (1) + (inner 57 (1) + length 0x02 (1) + 2 value bytes) = 6
+        val inner = Tlv.Primitive(Tag.fromHex("57"), byteArrayOf(0x10, 0x20))
+        val outer = Tlv.Constructed(Tag.fromHex("70"), listOf(inner))
+        assertEquals(6, encodedSize(outer))
+    }
+
+    @Test
+    fun `nested constructed depth 3 is recursively summed`() {
+        // L3 leaf: 57 (1) + len 0x02 (1) + 2 = 4
+        // L2 cons: A6 (1) + len 0x04 (1) + 4 = 6
+        // L1 cons: A5 (1) + len 0x06 (1) + 6 = 8
+        // L0 cons: 70 (1) + len 0x08 (1) + 8 = 10
+        val leaf = Tlv.Primitive(Tag.fromHex("57"), byteArrayOf(0x10, 0x20))
+        val l2 = Tlv.Constructed(Tag.fromHex("A6"), listOf(leaf))
+        val l1 = Tlv.Constructed(Tag.fromHex("A5"), listOf(l2))
+        val l0 = Tlv.Constructed(Tag.fromHex("70"), listOf(l1))
+        assertEquals(10, encodedSize(l0))
+    }
+
+    @Test
+    fun `constructed body crossing 0x7F triggers long-form length`() {
+        // 200 children of size 1 each (tag 5A + len 0 = 2 bytes) = 400 body bytes
+        val children = List(200) { Tlv.Primitive(Tag.fromHex("5A"), ByteArray(0)) }
+        // outer tag 70 (1) + length 0x82 0x01 0x90 (3) + 400 = 404
+        val outer = Tlv.Constructed(Tag.fromHex("70"), children)
+        assertEquals(404, encodedSize(outer))
+    }
+
+    @Test
+    fun `encodedSize rejects trees deeper than MAX_DEPTH with IllegalStateException`() {
+        var node: Tlv = Tlv.Primitive(Tag.fromHex("57"), ByteArray(0))
+        repeat(MAX_DEPTH + 2) {
+            node = Tlv.Constructed(Tag.fromHex("70"), listOf(node))
+        }
+        assertFailsWith<IllegalStateException> { encodedSize(node) }
+    }
+}

--- a/shared/src/commonTest/kotlin/io/github/a7asoft/nfcemv/tlv/internal/LengthWriterTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/a7asoft/nfcemv/tlv/internal/LengthWriterTest.kt
@@ -1,0 +1,174 @@
+package io.github.a7asoft.nfcemv.tlv.internal
+
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class LengthWriterTest {
+
+    @Test
+    fun `lengthOctets is 1 for length 0`() {
+        assertEquals(1, lengthOctets(0))
+    }
+
+    @Test
+    fun `writeLength encodes 0 as a single 0x00 byte`() {
+        val dst = ByteArray(1)
+        val end = writeLength(0, dst, 0)
+        assertEquals(1, end)
+        assertContentEquals(byteArrayOf(0x00), dst)
+    }
+
+    @Test
+    fun `writeLength encodes 0x7F as a single 0x7F byte`() {
+        val dst = ByteArray(1)
+        val end = writeLength(0x7F, dst, 0)
+        assertEquals(1, end)
+        assertContentEquals(byteArrayOf(0x7F), dst)
+    }
+
+    @Test
+    fun `lengthOctets is 1 for length 0x7F`() {
+        assertEquals(1, lengthOctets(0x7F))
+    }
+
+    @Test
+    fun `writeLength encodes 0x80 as 0x81 0x80`() {
+        val dst = ByteArray(2)
+        val end = writeLength(0x80, dst, 0)
+        assertEquals(2, end)
+        assertContentEquals(byteArrayOf(0x81.toByte(), 0x80.toByte()), dst)
+    }
+
+    @Test
+    fun `writeLength encodes 0xFF as 0x81 0xFF`() {
+        val dst = ByteArray(2)
+        val end = writeLength(0xFF, dst, 0)
+        assertEquals(2, end)
+        assertContentEquals(byteArrayOf(0x81.toByte(), 0xFF.toByte()), dst)
+    }
+
+    @Test
+    fun `lengthOctets is 2 for length 0x80`() {
+        assertEquals(2, lengthOctets(0x80))
+    }
+
+    @Test
+    fun `lengthOctets is 2 for length 0xFF`() {
+        assertEquals(2, lengthOctets(0xFF))
+    }
+
+    @Test
+    fun `writeLength encodes 0x100 as 0x82 0x01 0x00`() {
+        val dst = ByteArray(3)
+        val end = writeLength(0x100, dst, 0)
+        assertEquals(3, end)
+        assertContentEquals(byteArrayOf(0x82.toByte(), 0x01, 0x00), dst)
+    }
+
+    @Test
+    fun `writeLength encodes 0xFFFF as 0x82 0xFF 0xFF`() {
+        val dst = ByteArray(3)
+        val end = writeLength(0xFFFF, dst, 0)
+        assertEquals(3, end)
+        assertContentEquals(byteArrayOf(0x82.toByte(), 0xFF.toByte(), 0xFF.toByte()), dst)
+    }
+
+    @Test
+    fun `lengthOctets is 3 for length 0x100`() {
+        assertEquals(3, lengthOctets(0x100))
+    }
+
+    @Test
+    fun `lengthOctets is 3 for length 0xFFFF`() {
+        assertEquals(3, lengthOctets(0xFFFF))
+    }
+
+    @Test
+    fun `writeLength encodes 0x10000 as 0x83 0x01 0x00 0x00`() {
+        val dst = ByteArray(4)
+        val end = writeLength(0x10000, dst, 0)
+        assertEquals(4, end)
+        assertContentEquals(byteArrayOf(0x83.toByte(), 0x01, 0x00, 0x00), dst)
+    }
+
+    @Test
+    fun `writeLength encodes 0x1000000 as 0x84 0x01 0x00 0x00 0x00`() {
+        val dst = ByteArray(5)
+        val end = writeLength(0x1000000, dst, 0)
+        assertEquals(5, end)
+        assertContentEquals(
+            byteArrayOf(0x84.toByte(), 0x01, 0x00, 0x00, 0x00),
+            dst,
+        )
+    }
+
+    @Test
+    fun `writeLength encodes Int MAX_VALUE as 0x84 0x7F 0xFF 0xFF 0xFF`() {
+        val dst = ByteArray(5)
+        val end = writeLength(Int.MAX_VALUE, dst, 0)
+        assertEquals(5, end)
+        assertContentEquals(
+            byteArrayOf(0x84.toByte(), 0x7F, 0xFF.toByte(), 0xFF.toByte(), 0xFF.toByte()),
+            dst,
+        )
+    }
+
+    @Test
+    fun `lengthOctets is 4 for length 0x10000`() {
+        assertEquals(4, lengthOctets(0x10000))
+    }
+
+    @Test
+    fun `lengthOctets is 5 for length Int MAX_VALUE`() {
+        assertEquals(5, lengthOctets(Int.MAX_VALUE))
+    }
+
+    @Test
+    fun `writeLength writes at the requested offset and leaves earlier bytes untouched`() {
+        val dst = ByteArray(5)
+        dst[0] = 0xAA.toByte()
+        dst[1] = 0xBB.toByte()
+        val end = writeLength(0x100, dst, offset = 2)
+        assertEquals(5, end)
+        assertContentEquals(
+            byteArrayOf(0xAA.toByte(), 0xBB.toByte(), 0x82.toByte(), 0x01, 0x00),
+            dst,
+        )
+    }
+
+    @Test
+    fun `writeLength rejects negative input`() {
+        val dst = ByteArray(1)
+        assertFailsWith<IllegalArgumentException> { writeLength(-1, dst, 0) }
+    }
+
+    @Test
+    fun `lengthOctets rejects negative input`() {
+        assertFailsWith<IllegalArgumentException> { lengthOctets(-1) }
+    }
+
+    @Test
+    fun `writeLength rejects insufficient destination space`() {
+        val dst = ByteArray(2)
+        assertFailsWith<IllegalArgumentException> { writeLength(0x100, dst, offset = 0) }
+    }
+
+    @Test
+    fun `writeLength rejects offset that pushes past dst end`() {
+        val dst = ByteArray(3)
+        assertFailsWith<IllegalArgumentException> { writeLength(0x100, dst, offset = 1) }
+    }
+
+    @Test
+    fun `writeLength fits exactly into lengthOctets bytes for every boundary value`() {
+        listOf(0, 0x7F, 0x80, 0xFF, 0x100, 0xFFFF, 0x10000, 0x1000000, Int.MAX_VALUE)
+            .forEach { value ->
+                val expected = lengthOctets(value)
+                val dst = ByteArray(expected)
+                val end = writeLength(value, dst, offset = 0)
+                assertEquals(expected, end, "writeLength end mismatch for $value")
+            }
+    }
+}

--- a/shared/src/commonTest/kotlin/io/github/a7asoft/nfcemv/tlv/internal/NodeWriterTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/a7asoft/nfcemv/tlv/internal/NodeWriterTest.kt
@@ -1,0 +1,129 @@
+package io.github.a7asoft.nfcemv.tlv.internal
+
+import io.github.a7asoft.nfcemv.tlv.Tag
+import io.github.a7asoft.nfcemv.tlv.Tlv
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class NodeWriterTest {
+
+    @Test
+    fun `writes a primitive with single-byte tag and short-form length`() {
+        // 57 02 10 20
+        val node = Tlv.Primitive(Tag.fromHex("57"), byteArrayOf(0x10, 0x20))
+        val dst = ByteArray(encodedSize(node))
+        val end = writeNode(node, dst, offset = 0, depth = 0)
+        assertEquals(4, end)
+        assertContentEquals(byteArrayOf(0x57, 0x02, 0x10, 0x20), dst)
+    }
+
+    @Test
+    fun `writes a primitive with multi-byte tag`() {
+        // 9F 02 03 11 22 33
+        val node = Tlv.Primitive(Tag.fromHex("9F02"), byteArrayOf(0x11, 0x22, 0x33))
+        val dst = ByteArray(encodedSize(node))
+        val end = writeNode(node, dst, offset = 0, depth = 0)
+        assertEquals(6, end)
+        assertContentEquals(
+            byteArrayOf(0x9F.toByte(), 0x02, 0x03, 0x11, 0x22, 0x33),
+            dst,
+        )
+    }
+
+    @Test
+    fun `writes a primitive with long-form length`() {
+        // 5A 81 80 00 00 ... (128 zero bytes)
+        val node = Tlv.Primitive(Tag.fromHex("5A"), ByteArray(0x80))
+        val dst = ByteArray(encodedSize(node))
+        val end = writeNode(node, dst, offset = 0, depth = 0)
+        assertEquals(131, end)
+        assertEquals(0x5A.toByte(), dst[0])
+        assertEquals(0x81.toByte(), dst[1])
+        assertEquals(0x80.toByte(), dst[2])
+        assertEquals(0x00.toByte(), dst[3])
+        assertEquals(0x00.toByte(), dst[130])
+    }
+
+    @Test
+    fun `writes a constructed node with one child`() {
+        // 70 04 | 57 02 10 20
+        val inner = Tlv.Primitive(Tag.fromHex("57"), byteArrayOf(0x10, 0x20))
+        val node = Tlv.Constructed(Tag.fromHex("70"), listOf(inner))
+        val dst = ByteArray(encodedSize(node))
+        val end = writeNode(node, dst, offset = 0, depth = 0)
+        assertEquals(6, end)
+        assertContentEquals(
+            byteArrayOf(0x70, 0x04, 0x57, 0x02, 0x10, 0x20),
+            dst,
+        )
+    }
+
+    @Test
+    fun `writes a constructed node with multiple children in source order`() {
+        // 70 06 | 57 01 10 | 5A 01 20
+        val a = Tlv.Primitive(Tag.fromHex("57"), byteArrayOf(0x10))
+        val b = Tlv.Primitive(Tag.fromHex("5A"), byteArrayOf(0x20))
+        val node = Tlv.Constructed(Tag.fromHex("70"), listOf(a, b))
+        val dst = ByteArray(encodedSize(node))
+        val end = writeNode(node, dst, offset = 0, depth = 0)
+        assertEquals(8, end)
+        assertContentEquals(
+            byteArrayOf(0x70, 0x06, 0x57, 0x01, 0x10, 0x5A, 0x01, 0x20),
+            dst,
+        )
+    }
+
+    @Test
+    fun `writes nested constructed depth 3 in pre-order`() {
+        // 70 08 | A5 06 | A6 04 | 57 02 10 20
+        val leaf = Tlv.Primitive(Tag.fromHex("57"), byteArrayOf(0x10, 0x20))
+        val l2 = Tlv.Constructed(Tag.fromHex("A6"), listOf(leaf))
+        val l1 = Tlv.Constructed(Tag.fromHex("A5"), listOf(l2))
+        val l0 = Tlv.Constructed(Tag.fromHex("70"), listOf(l1))
+        val dst = ByteArray(encodedSize(l0))
+        val end = writeNode(l0, dst, offset = 0, depth = 0)
+        assertEquals(10, end)
+        assertContentEquals(
+            byteArrayOf(
+                0x70, 0x08,
+                0xA5.toByte(), 0x06,
+                0xA6.toByte(), 0x04,
+                0x57, 0x02, 0x10, 0x20,
+            ),
+            dst,
+        )
+    }
+
+    @Test
+    fun `rejects Primitive whose tag has the constructed bit set`() {
+        val node = Tlv.Primitive(Tag.fromHex("70"), byteArrayOf(0x10))
+        val dst = ByteArray(encodedSize(node))
+        assertFailsWith<IllegalArgumentException> { writeNode(node, dst, offset = 0, depth = 0) }
+    }
+
+    @Test
+    fun `rejects Constructed whose tag has the primitive bit set`() {
+        val leaf = Tlv.Primitive(Tag.fromHex("9F36"), ByteArray(0))
+        val node = Tlv.Constructed(Tag.fromHex("57"), listOf(leaf))
+        val dst = ByteArray(encodedSize(node))
+        assertFailsWith<IllegalArgumentException> { writeNode(node, dst, offset = 0, depth = 0) }
+    }
+
+    @Test
+    fun `rejects trees deeper than MAX_DEPTH`() {
+        // Build a chain of MAX_DEPTH + 2 constructed nodes wrapping a leaf so
+        // the recursion definitely exceeds the bound on the way down. dst is
+        // sized generously rather than via encodedSize, since encodedSize also
+        // enforces MAX_DEPTH and would mask the writeNode-side guard under test.
+        var node: Tlv = Tlv.Primitive(Tag.fromHex("57"), ByteArray(0))
+        repeat(MAX_DEPTH + 2) {
+            node = Tlv.Constructed(Tag.fromHex("70"), listOf(node))
+        }
+        val dst = ByteArray(4 * (MAX_DEPTH + 4))
+        assertFailsWith<IllegalStateException> {
+            writeNode(node, dst, offset = 0, depth = 0)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Brings the BER-TLV encoder (issue #2) to \`main\`, completing the core-parser milestone. Single-commit release branch — built clean off \`main\` to avoid the inherited \`Co-authored-by\` trailers and overlapping squash content that conflicted in the previous attempt (#18, closed).

## What changes vs main

- **New**: \`TlvEncoder.encode(node)\` and \`TlvEncoder.encode(nodes)\` plus internal helpers (\`EncodedSize\`, \`LengthWriter\`, \`NodeWriter\`, \`EncoderConstants\`).
- **New**: \`internal fun Tlv.Primitive.writeValueInto(dst, offset)\` — single-defensive-copy primitive writer used by the encoder.
- **Updated**: \`shared/README.md\` (encoder quickstart, fixed stale \`tlv.value.size\` → \`tlv.length\`, added \`LengthOverflow\` row, refreshed \`NonMinimalTagEncoding\` description).
- **Updated**: \`docs/recipes/parse-tlv.md\` (re-emit section + PCI-safety warning).
- **Updated**: \`CHANGELOG.md\` (Unreleased entry under #2).
- **+12 test files / 195 total tests on commonTest**: round-trip fixtures, 20K-iteration fuzz, PCI masking parity for 5A/57/9F26, cross-function consistency property, depth-overflow + P/C-bit invariant tests.

## Properties pinned

- DER-canonical output (definite length, minimal length octets, no options)
- Round-trip invariant: \`decode(encode(x)) == x\` for any decoder-Ok input
- Defense-in-depth \`MAX_DEPTH = 64\` propagated to BOTH encoder passes
- ISO/IEC 8825-1 §8.1.2.5 P/C-bit invariant enforced on caller-built trees
- \`Int\`-overflow guards on every size-aggregation path
- \`LengthWriter\` destination-bounds precondition

## Test plan
- [x] \`./gradlew :shared:allTests\` clean — 195 tests
- [x] \`./gradlew :composeApp:assembleDebug\` clean
- [ ] CI green
- [ ] Tag \`v0.1.0\` (or \`v0.1.0-SNAPSHOT\`) on the merge commit if releasing to a snapshot repo