### PR TITLE
feat(validation): Luhn check (#7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ All notable changes to this project will be documented here. The format follows 
 - An earlier draft included a `rejectTrailingBytes` option intended to catch APDU responses passed in with SW1 SW2 still attached. Removed because at the BER-TLV layer `90 00` decodes as a valid empty primitive, not as trailing bytes — SW detection belongs to the transport layer.
 - Wizard-generated scaffold (`Greeting.kt`, `Platform.kt`, `SharedCommonTest.example`) cleaned up.
 
+### Added — Luhn validation (#7)
+- `String.isValidLuhn()` extension in `commonMain` package `io.github.a7asoft.nfcemv.validation` per ISO/IEC 7812-1 Annex B.
+- Predicate semantics: empty input, non-digit characters, embedded whitespace, and any non-`'0'..'9'` codepoint all return `false`. Length-agnostic (PAN length bounds belong to `Pan` per #5).
+- Property-tested against a textbook reference implementation across 1,000 random digit strings.
+
 ### Added — engineering setup
 - `CLAUDE.md` engineering rules (architecture, SOLID, code style, testing discipline §6.1).
 - `.claude/agents/` project-scoped reviewers: `emv-nfc-expert`, `pci-security-reviewer`.

--- a/shared/README.md
+++ b/shared/README.md
@@ -8,6 +8,7 @@ Pure-Kotlin core for the nfc-emv-toolkit. Lives in `commonMain` and ships with n
 |---------|---------|
 | `io.github.a7asoft.nfcemv.tlv` | BER-TLV decoder + encoder (this milestone) |
 | `io.github.a7asoft.nfcemv.tlv.internal` | Reader cursor, tag/length/node decoders, padding skipper. Internal — do not depend on these symbols. |
+| `io.github.a7asoft.nfcemv.validation` | Luhn check (this milestone) |
 
 Future packages (later issues): `emv` (tag dictionary), `brand` (AID + BIN brand resolution), `extract` (PAN, Track2, expiry), `validation` (Luhn, format checks).
 
@@ -100,6 +101,18 @@ if (parsed is TlvParseResult.Ok) {
 The encoder takes no options. Output is always X.690 DER-canonical (definite length, minimal length octets). If the original card response used non-minimal length octets (uncommon), the re-emitted bytes will be shorter but **semantically identical** — a second `TlvDecoder.parse` produces the same `Tlv` tree.
 
 Defense-in-depth: a hardcoded `MAX_DEPTH = 64` guard fires `IllegalStateException` on caller-built trees that exceed it (the decoder's `TlvOptions.maxDepth` defaults to 16; the encoder's higher cap accommodates any tree the decoder accepts).
+
+## Validation
+
+`String.isValidLuhn(): Boolean` — Luhn / mod-10 checksum per ISO/IEC 7812-1 Annex B. Predicate; never throws. Use to gate untrusted PAN inputs before constructing `Pan` (#5 once it ships).
+
+```kotlin
+import io.github.a7asoft.nfcemv.validation.isValidLuhn
+
+if ("4111111111111111".isValidLuhn()) {
+    // proceed
+}
+```
 
 ## Tests
 

--- a/shared/src/commonMain/kotlin/io/github/a7asoft/nfcemv/validation/Luhn.kt
+++ b/shared/src/commonMain/kotlin/io/github/a7asoft/nfcemv/validation/Luhn.kt
@@ -1,0 +1,28 @@
+package io.github.a7asoft.nfcemv.validation
+
+/**
+ * Validate this string as a Luhn-checked numeric identifier per
+ * ISO/IEC 7812-1 Annex B (mod-10 checksum).
+ *
+ * Predicate semantics: returns `true` only when the string is non-empty,
+ * contains digits exclusively, and the Luhn checksum evaluates to a
+ * multiple of ten. Empty input, embedded whitespace, letters, or any
+ * non-digit codepoint all return `false` — no exceptions are thrown.
+ *
+ * The function is length-agnostic (this layer does not enforce PAN length
+ * bounds; that is the responsibility of `Pan` once it ships per #5).
+ *
+ * Limitations of the algorithm itself: Luhn does not detect transpositions
+ * `09 ↔ 90` nor twin errors `22 ↔ 55`, `33 ↔ 66`, `44 ↔ 77`. All other
+ * single-digit errors and adjacent-digit transpositions are caught.
+ */
+public fun String.isValidLuhn(): Boolean {
+    if (isEmpty() || any { it !in '0'..'9' }) return false
+    val lastIndex = length - 1
+    val sum = indices.sumOf { i ->
+        val digit = this[i].code - '0'.code
+        val doubled = if ((lastIndex - i) % 2 == 1) digit * 2 else digit
+        if (doubled > 9) doubled - 9 else doubled
+    }
+    return sum % 10 == 0
+}

--- a/shared/src/commonMain/kotlin/io/github/a7asoft/nfcemv/validation/Luhn.kt
+++ b/shared/src/commonMain/kotlin/io/github/a7asoft/nfcemv/validation/Luhn.kt
@@ -9,6 +9,11 @@ package io.github.a7asoft.nfcemv.validation
  * multiple of ten. Empty input, embedded whitespace, letters, or any
  * non-digit codepoint all return `false` — no exceptions are thrown.
  *
+ * ASCII digits only: Arabic-Indic (`'٠'..'٩'`), fullwidth (`'０'..'９'`),
+ * and any other non-`'0'..'9'` codepoint are rejected. Use this as a strict
+ * gate on inputs that should be plain ASCII numeric identifiers; do NOT
+ * pre-normalize to ASCII before calling — let the predicate reject.
+ *
  * The function is length-agnostic (this layer does not enforce PAN length
  * bounds; that is the responsibility of `Pan` once it ships per #5).
  *

--- a/shared/src/commonTest/kotlin/io/github/a7asoft/nfcemv/validation/LuhnTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/a7asoft/nfcemv/validation/LuhnTest.kt
@@ -17,7 +17,7 @@ class LuhnTest {
     }
 
     @Test
-    fun `single non-zero digit is not a valid Luhn number unless it is zero`() {
+    fun `single non-zero digit is not a valid Luhn number`() {
         assertFalse("1".isValidLuhn())
         assertFalse("9".isValidLuhn())
     }
@@ -40,8 +40,8 @@ class LuhnTest {
     @Test
     fun `punctuation and unicode are rejected`() {
         assertFalse("4111-1111-1111-1111".isValidLuhn())
-        assertFalse("4111 1111".isValidLuhn()) // non-breaking space
-        assertFalse("4111　1111".isValidLuhn()) // ideographic space
+        assertFalse("4111 1111".isValidLuhn()) // U+00A0 non-breaking space
+        assertFalse("4111　1111".isValidLuhn()) // U+3000 ideographic space
     }
 
     @Test
@@ -93,7 +93,7 @@ class LuhnTest {
     }
 
     @Test
-    fun `8-digit minimum PAN length validates`() {
+    fun `8-digit all-zero string is Luhn-valid`() {
         assertTrue("00000000".isValidLuhn())
     }
 
@@ -110,10 +110,14 @@ class LuhnTest {
     }
 
     @Test
-    fun `leading zeros do not affect validity`() {
+    fun `prepending leading zeros to a valid number preserves Luhn validity`() {
         assertTrue("4111111111111111".isValidLuhn())
         assertTrue("04111111111111111".isValidLuhn())
         assertTrue("00004111111111111111".isValidLuhn())
+    }
+
+    @Test
+    fun `prepending leading zeros to an invalid number does not make it valid`() {
         assertFalse("4111111111111112".isValidLuhn())
         assertFalse("00004111111111111112".isValidLuhn())
     }
@@ -129,7 +133,7 @@ class LuhnTest {
     @Test
     fun `agrees with a reference Luhn implementation on 1000 random digit strings`() {
         val rng = kotlin.random.Random(SEED)
-        repeat(ITERATIONS) {
+        repeat(ITERATIONS) { iteration ->
             val len = rng.nextInt(1, MAX_LENGTH + 1)
             val s = buildString(len) {
                 repeat(len) { append(rng.nextInt(10)) }
@@ -137,7 +141,7 @@ class LuhnTest {
             kotlin.test.assertEquals(
                 referenceLuhn(s),
                 s.isValidLuhn(),
-                "mismatch for input $s",
+                "mismatch at iteration $iteration, length=$len",
             )
         }
     }

--- a/shared/src/commonTest/kotlin/io/github/a7asoft/nfcemv/validation/LuhnTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/a7asoft/nfcemv/validation/LuhnTest.kt
@@ -125,4 +125,40 @@ class LuhnTest {
         assertTrue("000".isValidLuhn())
         assertTrue("0000000000000000".isValidLuhn())
     }
+
+    @Test
+    fun `agrees with a reference Luhn implementation on 1000 random digit strings`() {
+        val rng = kotlin.random.Random(SEED)
+        repeat(ITERATIONS) {
+            val len = rng.nextInt(1, MAX_LENGTH + 1)
+            val s = buildString(len) {
+                repeat(len) { append(rng.nextInt(10)) }
+            }
+            kotlin.test.assertEquals(
+                referenceLuhn(s),
+                s.isValidLuhn(),
+                "mismatch for input $s",
+            )
+        }
+    }
+
+    private fun referenceLuhn(s: String): Boolean {
+        if (s.isEmpty()) return false
+        val digits = s.reversed().map { it - '0' }
+        val sum = digits.withIndex().sumOf { (i, d) ->
+            if (i % 2 == 1) {
+                val doubled = d * 2
+                if (doubled > 9) doubled - 9 else doubled
+            } else {
+                d
+            }
+        }
+        return sum % 10 == 0
+    }
+
+    private companion object {
+        const val SEED: Long = 0x4C55484EL
+        const val ITERATIONS: Int = 1_000
+        const val MAX_LENGTH: Int = 24
+    }
 }

--- a/shared/src/commonTest/kotlin/io/github/a7asoft/nfcemv/validation/LuhnTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/a7asoft/nfcemv/validation/LuhnTest.kt
@@ -43,4 +43,34 @@ class LuhnTest {
         assertFalse("4111 1111".isValidLuhn()) // non-breaking space
         assertFalse("4111　1111".isValidLuhn()) // ideographic space
     }
+
+    @Test
+    fun `Visa test PAN 4111111111111111 is valid`() {
+        assertTrue("4111111111111111".isValidLuhn())
+    }
+
+    @Test
+    fun `Mastercard test PAN 5555555555554444 is valid`() {
+        assertTrue("5555555555554444".isValidLuhn())
+    }
+
+    @Test
+    fun `Amex 15-digit test PAN 378282246310005 is valid`() {
+        assertTrue("378282246310005".isValidLuhn())
+    }
+
+    @Test
+    fun `Discover test PAN 6011111111111117 is valid`() {
+        assertTrue("6011111111111117".isValidLuhn())
+    }
+
+    @Test
+    fun `JCB test PAN 3530111333300000 is valid`() {
+        assertTrue("3530111333300000".isValidLuhn())
+    }
+
+    @Test
+    fun `Diners test PAN 30569309025904 is valid`() {
+        assertTrue("30569309025904".isValidLuhn())
+    }
 }

--- a/shared/src/commonTest/kotlin/io/github/a7asoft/nfcemv/validation/LuhnTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/a7asoft/nfcemv/validation/LuhnTest.kt
@@ -73,4 +73,22 @@ class LuhnTest {
     fun `Diners test PAN 30569309025904 is valid`() {
         assertTrue("30569309025904".isValidLuhn())
     }
+
+    @Test
+    fun `Visa test PAN with corrupted check digit is invalid`() {
+        assertFalse("4111111111111112".isValidLuhn())
+    }
+
+    @Test
+    fun `Visa test PAN with one mid-string digit changed is invalid`() {
+        assertFalse("4111111111121111".isValidLuhn())
+    }
+
+    @Test
+    fun `Mastercard test PAN with adjacent transposition is invalid`() {
+        // 5555555555554444 (valid) → 5555555555545444 (swap indices 11 and 12)
+        // Confirms adjacent-digit transposition is detected (Luhn catches
+        // most but not 09↔90 / 22↔55 / 33↔66 / 44↔77 — see KDoc).
+        assertFalse("5555555555545444".isValidLuhn())
+    }
 }

--- a/shared/src/commonTest/kotlin/io/github/a7asoft/nfcemv/validation/LuhnTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/a7asoft/nfcemv/validation/LuhnTest.kt
@@ -91,4 +91,38 @@ class LuhnTest {
         // most but not 09↔90 / 22↔55 / 33↔66 / 44↔77 — see KDoc).
         assertFalse("5555555555545444".isValidLuhn())
     }
+
+    @Test
+    fun `8-digit minimum PAN length validates`() {
+        assertTrue("00000000".isValidLuhn())
+    }
+
+    @Test
+    fun `13-digit legacy Visa PAN validates`() {
+        assertTrue("4222222222222".isValidLuhn())
+    }
+
+    @Test
+    fun `19-digit max-length PAN validates`() {
+        // Leading zeros do not affect Luhn (per ISO/IEC 7812-1 Annex B); use
+        // a 16-digit Visa test PAN with three leading zeros to reach 19.
+        assertTrue("0004111111111111111".isValidLuhn())
+    }
+
+    @Test
+    fun `leading zeros do not affect validity`() {
+        assertTrue("4111111111111111".isValidLuhn())
+        assertTrue("04111111111111111".isValidLuhn())
+        assertTrue("00004111111111111111".isValidLuhn())
+        assertFalse("4111111111111112".isValidLuhn())
+        assertFalse("00004111111111111112".isValidLuhn())
+    }
+
+    @Test
+    fun `all-zero strings of arbitrary length validate`() {
+        assertTrue("0".isValidLuhn())
+        assertTrue("00".isValidLuhn())
+        assertTrue("000".isValidLuhn())
+        assertTrue("0000000000000000".isValidLuhn())
+    }
 }

--- a/shared/src/commonTest/kotlin/io/github/a7asoft/nfcemv/validation/LuhnTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/a7asoft/nfcemv/validation/LuhnTest.kt
@@ -21,4 +21,26 @@ class LuhnTest {
         assertFalse("1".isValidLuhn())
         assertFalse("9".isValidLuhn())
     }
+
+    @Test
+    fun `whitespace inside string is rejected`() {
+        assertFalse("4111 1111 1111 1111".isValidLuhn())
+        assertFalse(" 4111111111111111".isValidLuhn())
+        assertFalse("4111111111111111 ".isValidLuhn())
+    }
+
+    @Test
+    fun `letters anywhere in string are rejected`() {
+        assertFalse("a".isValidLuhn())
+        assertFalse("411a111111111111".isValidLuhn())
+        assertFalse("4111111111111111a".isValidLuhn())
+        assertFalse("a4111111111111111".isValidLuhn())
+    }
+
+    @Test
+    fun `punctuation and unicode are rejected`() {
+        assertFalse("4111-1111-1111-1111".isValidLuhn())
+        assertFalse("4111 1111".isValidLuhn()) // non-breaking space
+        assertFalse("4111　1111".isValidLuhn()) // ideographic space
+    }
 }

--- a/shared/src/commonTest/kotlin/io/github/a7asoft/nfcemv/validation/LuhnTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/a7asoft/nfcemv/validation/LuhnTest.kt
@@ -1,0 +1,24 @@
+package io.github.a7asoft.nfcemv.validation
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class LuhnTest {
+
+    @Test
+    fun `empty string is not a valid Luhn number`() {
+        assertFalse("".isValidLuhn())
+    }
+
+    @Test
+    fun `single zero is a valid Luhn number`() {
+        assertTrue("0".isValidLuhn())
+    }
+
+    @Test
+    fun `single non-zero digit is not a valid Luhn number unless it is zero`() {
+        assertFalse("1".isValidLuhn())
+        assertFalse("9".isValidLuhn())
+    }
+}


### PR DESCRIPTION
## Summary

Implements issue #7: \`String.isValidLuhn()\` extension in \`commonMain\` per ISO/IEC 7812-1 Annex B. Standalone Luhn / mod-10 checksum gate for PAN-shaped digit strings.

- **API**: \`fun String.isValidLuhn(): Boolean\` in package \`io.github.a7asoft.nfcemv.validation\` (new package).
- **Predicate semantics**: returns \`Boolean\`, never throws. Empty input, embedded whitespace, letters, punctuation, and any non-digit codepoint return \`false\`.
- **Length-agnostic**: PAN length bounds (8–19 digits per ISO 7812) belong to \`Pan\` per #5; this layer is pure algorithm.
- **Algorithm**: short-circuit non-digit guard via \`any { it !in '0'..'9' }\`, then \`indices.sumOf { … }\` over big-endian indices with right-aligned parity. No \`var\`, no allocations beyond the implicit IntRange iterator. Single-expression body for the inner reduction.
- **Property tested**: 1,000 random digit strings (length 1–24, seed \`0x4C55484E\`) against a textbook reference implementation; full agreement.

## Test plan
- [x] \`./gradlew :shared:allTests\` clean — 21 tests in \`LuhnTest\`
- [x] \`./gradlew :composeApp:assembleDebug\` clean
- [x] Known-valid: Visa 4111111111111111, MC 5555555555554444, Amex 378282246310005, Discover 6011111111111117, JCB 3530111333300000, Diners 30569309025904, legacy Visa 4222222222222
- [x] Known-invalid: corrupted check digit, mid-string digit flip, adjacent transposition (5555555555545444)
- [x] Boundaries: empty, single digit, 8d, 13d, 16d, 19d
- [x] Leading-zero invariance pinned
- [x] Non-digit rejection: whitespace, letters, punctuation, unicode (NBSP, ideographic space)

## Process notes
Built via subagent-driven TDD. Implementer caught a bug in the plan's Task 5 fixture (\`5555555555544544\` is actually Luhn-valid) and stopped per CLAUDE.md §6.1 instead of silently weakening the test. Fix authorized: replaced with \`5555555555545444\` (true adjacent swap of positions 11/12), verified Luhn-invalid.