### PR TITLE
release: Luhn validation (v0.1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ All notable changes to this project will be documented here. The format follows 
 - An earlier draft included a `rejectTrailingBytes` option intended to catch APDU responses passed in with SW1 SW2 still attached. Removed because at the BER-TLV layer `90 00` decodes as a valid empty primitive, not as trailing bytes — SW detection belongs to the transport layer.
 - Wizard-generated scaffold (`Greeting.kt`, `Platform.kt`, `SharedCommonTest.example`) cleaned up.
 
+### Added — Luhn validation (#7)
+- `String.isValidLuhn()` extension in `commonMain` package `io.github.a7asoft.nfcemv.validation` per ISO/IEC 7812-1 Annex B.
+- Predicate semantics: empty input, non-digit characters, embedded whitespace, and any non-`'0'..'9'` codepoint all return `false`. Length-agnostic (PAN length bounds belong to `Pan` per #5).
+- Property-tested against a textbook reference implementation across 1,000 random digit strings.
+
 ### Added — engineering setup
 - `CLAUDE.md` engineering rules (architecture, SOLID, code style, testing discipline §6.1).
 - `.claude/agents/` project-scoped reviewers: `emv-nfc-expert`, `pci-security-reviewer`.

--- a/shared/README.md
+++ b/shared/README.md
@@ -8,6 +8,7 @@ Pure-Kotlin core for the nfc-emv-toolkit. Lives in `commonMain` and ships with n
 |---------|---------|
 | `io.github.a7asoft.nfcemv.tlv` | BER-TLV decoder + encoder (this milestone) |
 | `io.github.a7asoft.nfcemv.tlv.internal` | Reader cursor, tag/length/node decoders, padding skipper. Internal — do not depend on these symbols. |
+| `io.github.a7asoft.nfcemv.validation` | Luhn check (this milestone) |
 
 Future packages (later issues): `emv` (tag dictionary), `brand` (AID + BIN brand resolution), `extract` (PAN, Track2, expiry), `validation` (Luhn, format checks).
 
@@ -100,6 +101,18 @@ if (parsed is TlvParseResult.Ok) {
 The encoder takes no options. Output is always X.690 DER-canonical (definite length, minimal length octets). If the original card response used non-minimal length octets (uncommon), the re-emitted bytes will be shorter but **semantically identical** — a second `TlvDecoder.parse` produces the same `Tlv` tree.
 
 Defense-in-depth: a hardcoded `MAX_DEPTH = 64` guard fires `IllegalStateException` on caller-built trees that exceed it (the decoder's `TlvOptions.maxDepth` defaults to 16; the encoder's higher cap accommodates any tree the decoder accepts).
+
+## Validation
+
+`String.isValidLuhn(): Boolean` — Luhn / mod-10 checksum per ISO/IEC 7812-1 Annex B. Predicate; never throws. Use to gate untrusted PAN inputs before constructing `Pan` (#5 once it ships).
+
+```kotlin
+import io.github.a7asoft.nfcemv.validation.isValidLuhn
+
+if ("4111111111111111".isValidLuhn()) {
+    // proceed
+}
+```
 
 ## Tests
 

--- a/shared/src/commonMain/kotlin/io/github/a7asoft/nfcemv/validation/Luhn.kt
+++ b/shared/src/commonMain/kotlin/io/github/a7asoft/nfcemv/validation/Luhn.kt
@@ -1,0 +1,33 @@
+package io.github.a7asoft.nfcemv.validation
+
+/**
+ * Validate this string as a Luhn-checked numeric identifier per
+ * ISO/IEC 7812-1 Annex B (mod-10 checksum).
+ *
+ * Predicate semantics: returns `true` only when the string is non-empty,
+ * contains digits exclusively, and the Luhn checksum evaluates to a
+ * multiple of ten. Empty input, embedded whitespace, letters, or any
+ * non-digit codepoint all return `false` — no exceptions are thrown.
+ *
+ * ASCII digits only: Arabic-Indic (`'٠'..'٩'`), fullwidth (`'０'..'９'`),
+ * and any other non-`'0'..'9'` codepoint are rejected. Use this as a strict
+ * gate on inputs that should be plain ASCII numeric identifiers; do NOT
+ * pre-normalize to ASCII before calling — let the predicate reject.
+ *
+ * The function is length-agnostic (this layer does not enforce PAN length
+ * bounds; that is the responsibility of `Pan` once it ships per #5).
+ *
+ * Limitations of the algorithm itself: Luhn does not detect transpositions
+ * `09 ↔ 90` nor twin errors `22 ↔ 55`, `33 ↔ 66`, `44 ↔ 77`. All other
+ * single-digit errors and adjacent-digit transpositions are caught.
+ */
+public fun String.isValidLuhn(): Boolean {
+    if (isEmpty() || any { it !in '0'..'9' }) return false
+    val lastIndex = length - 1
+    val sum = indices.sumOf { i ->
+        val digit = this[i].code - '0'.code
+        val doubled = if ((lastIndex - i) % 2 == 1) digit * 2 else digit
+        if (doubled > 9) doubled - 9 else doubled
+    }
+    return sum % 10 == 0
+}

--- a/shared/src/commonTest/kotlin/io/github/a7asoft/nfcemv/validation/LuhnTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/a7asoft/nfcemv/validation/LuhnTest.kt
@@ -1,0 +1,168 @@
+package io.github.a7asoft.nfcemv.validation
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class LuhnTest {
+
+    @Test
+    fun `empty string is not a valid Luhn number`() {
+        assertFalse("".isValidLuhn())
+    }
+
+    @Test
+    fun `single zero is a valid Luhn number`() {
+        assertTrue("0".isValidLuhn())
+    }
+
+    @Test
+    fun `single non-zero digit is not a valid Luhn number`() {
+        assertFalse("1".isValidLuhn())
+        assertFalse("9".isValidLuhn())
+    }
+
+    @Test
+    fun `whitespace inside string is rejected`() {
+        assertFalse("4111 1111 1111 1111".isValidLuhn())
+        assertFalse(" 4111111111111111".isValidLuhn())
+        assertFalse("4111111111111111 ".isValidLuhn())
+    }
+
+    @Test
+    fun `letters anywhere in string are rejected`() {
+        assertFalse("a".isValidLuhn())
+        assertFalse("411a111111111111".isValidLuhn())
+        assertFalse("4111111111111111a".isValidLuhn())
+        assertFalse("a4111111111111111".isValidLuhn())
+    }
+
+    @Test
+    fun `punctuation and unicode are rejected`() {
+        assertFalse("4111-1111-1111-1111".isValidLuhn())
+        assertFalse("4111 1111".isValidLuhn()) // U+00A0 non-breaking space
+        assertFalse("4111　1111".isValidLuhn()) // U+3000 ideographic space
+    }
+
+    @Test
+    fun `Visa test PAN 4111111111111111 is valid`() {
+        assertTrue("4111111111111111".isValidLuhn())
+    }
+
+    @Test
+    fun `Mastercard test PAN 5555555555554444 is valid`() {
+        assertTrue("5555555555554444".isValidLuhn())
+    }
+
+    @Test
+    fun `Amex 15-digit test PAN 378282246310005 is valid`() {
+        assertTrue("378282246310005".isValidLuhn())
+    }
+
+    @Test
+    fun `Discover test PAN 6011111111111117 is valid`() {
+        assertTrue("6011111111111117".isValidLuhn())
+    }
+
+    @Test
+    fun `JCB test PAN 3530111333300000 is valid`() {
+        assertTrue("3530111333300000".isValidLuhn())
+    }
+
+    @Test
+    fun `Diners test PAN 30569309025904 is valid`() {
+        assertTrue("30569309025904".isValidLuhn())
+    }
+
+    @Test
+    fun `Visa test PAN with corrupted check digit is invalid`() {
+        assertFalse("4111111111111112".isValidLuhn())
+    }
+
+    @Test
+    fun `Visa test PAN with one mid-string digit changed is invalid`() {
+        assertFalse("4111111111121111".isValidLuhn())
+    }
+
+    @Test
+    fun `Mastercard test PAN with adjacent transposition is invalid`() {
+        // 5555555555554444 (valid) → 5555555555545444 (swap indices 11 and 12)
+        // Confirms adjacent-digit transposition is detected (Luhn catches
+        // most but not 09↔90 / 22↔55 / 33↔66 / 44↔77 — see KDoc).
+        assertFalse("5555555555545444".isValidLuhn())
+    }
+
+    @Test
+    fun `8-digit all-zero string is Luhn-valid`() {
+        assertTrue("00000000".isValidLuhn())
+    }
+
+    @Test
+    fun `13-digit legacy Visa PAN validates`() {
+        assertTrue("4222222222222".isValidLuhn())
+    }
+
+    @Test
+    fun `19-digit max-length PAN validates`() {
+        // Leading zeros do not affect Luhn (per ISO/IEC 7812-1 Annex B); use
+        // a 16-digit Visa test PAN with three leading zeros to reach 19.
+        assertTrue("0004111111111111111".isValidLuhn())
+    }
+
+    @Test
+    fun `prepending leading zeros to a valid number preserves Luhn validity`() {
+        assertTrue("4111111111111111".isValidLuhn())
+        assertTrue("04111111111111111".isValidLuhn())
+        assertTrue("00004111111111111111".isValidLuhn())
+    }
+
+    @Test
+    fun `prepending leading zeros to an invalid number does not make it valid`() {
+        assertFalse("4111111111111112".isValidLuhn())
+        assertFalse("00004111111111111112".isValidLuhn())
+    }
+
+    @Test
+    fun `all-zero strings of arbitrary length validate`() {
+        assertTrue("0".isValidLuhn())
+        assertTrue("00".isValidLuhn())
+        assertTrue("000".isValidLuhn())
+        assertTrue("0000000000000000".isValidLuhn())
+    }
+
+    @Test
+    fun `agrees with a reference Luhn implementation on 1000 random digit strings`() {
+        val rng = kotlin.random.Random(SEED)
+        repeat(ITERATIONS) { iteration ->
+            val len = rng.nextInt(1, MAX_LENGTH + 1)
+            val s = buildString(len) {
+                repeat(len) { append(rng.nextInt(10)) }
+            }
+            kotlin.test.assertEquals(
+                referenceLuhn(s),
+                s.isValidLuhn(),
+                "mismatch at iteration $iteration, length=$len",
+            )
+        }
+    }
+
+    private fun referenceLuhn(s: String): Boolean {
+        if (s.isEmpty()) return false
+        val digits = s.reversed().map { it - '0' }
+        val sum = digits.withIndex().sumOf { (i, d) ->
+            if (i % 2 == 1) {
+                val doubled = d * 2
+                if (doubled > 9) doubled - 9 else doubled
+            } else {
+                d
+            }
+        }
+        return sum % 10 == 0
+    }
+
+    private companion object {
+        const val SEED: Long = 0x4C55484EL
+        const val ITERATIONS: Int = 1_000
+        const val MAX_LENGTH: Int = 24
+    }
+}


### PR DESCRIPTION
## Summary

Promotes the Luhn / mod-10 checksum predicate (issue #7) to \`main\`. Single-commit release branch — built clean off \`main\` to avoid \`Co-authored-by\` trailers and overlapping squash content.

## What changes vs main

- **New**: \`String.isValidLuhn()\` extension in \`commonMain\` package \`io.github.a7asoft.nfcemv.validation\` per ISO/IEC 7812-1 Annex B.
- **Updated**: \`shared/README.md\` with a "Validation" section + new package row.
- **Updated**: \`CHANGELOG.md\` (Unreleased entry under #7).
- **+1 test file / 22 tests** in \`LuhnTest\`: PAN fixtures across 6 brands, length boundaries 1–19, leading-zero invariance, NBSP/ideographic-space rejection, 1,000-iteration property test against a reference implementation.

## Properties pinned

- ASCII digits only (Arabic-Indic, fullwidth, etc. rejected by design)
- Length-agnostic — PAN length bounds belong to \`Pan\` per #5
- Predicate semantics: never throws
- PCI-clean: failure messages on the property test embed only iteration + length, never the input

## Test plan
- [x] \`./gradlew :shared:allTests\` clean
- [x] \`./gradlew :composeApp:assembleDebug\` clean
- [x] CI green on the merge commit
- [x] Tag \`v0.1.1\` once merged