### PR TITLE
release: EMV tag dictionary (v0.1.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,12 @@ All notable changes to this project will be documented here. The format follows 
 - `ServiceCode` is a `@JvmInline value class` validating exactly three ASCII digits; service codes are categorical metadata, not PCI data, so `toString` returns the raw form.
 - New dependency: `org.jetbrains.kotlinx:kotlinx-datetime` (commonMain).
 
+### Added — EMV tag dictionary (#3)
+- New package `io.github.a7asoft.nfcemv.emv` with `EmvTagFormat`, `EmvTagLength` (sealed `Fixed` / `Variable`), `TagSensitivity` (`PCI` / `PUBLIC`), `EmvTagInfo`, and the `EmvTags` lookup object.
+- 27 entries covering EMV Book 3 / Book 4 staples plus contactless-kernel additions: AID, App Label, Track 2, PAN, Cardholder Name, Expiration / Effective Date, Country / Currency / Language, PAN Sequence, AIP, DF Name, CDOL1 / CDOL2, AFL, Amount, IAD, Preferred Name, ARQC, CID, ATC, Unpredictable Number, Signed Dynamic, Track 2 (Mastercard), CTQ, FCI Issuer Discretionary Data.
+- Each entry carries human-readable name, EMV format code (`N` / `AN` / `B` / `CN`), `Fixed(n)` or `Variable(maxBytes)` length, and a binary `PCI` / `PUBLIC` sensitivity flag. Names are paraphrased from EMV specs; no third-party listing is copied verbatim.
+- O(1) lookup via `EmvTags.lookup(tag)` (returns `null` for unknown tags); `EmvTags.all` returns entries in source order.
+
 ### Added — engineering setup
 - `CLAUDE.md` engineering rules (architecture, SOLID, code style, testing discipline §6.1).
 - `.claude/agents/` project-scoped reviewers: `emv-nfc-expert`, `pci-security-reviewer`.

--- a/shared/README.md
+++ b/shared/README.md
@@ -10,8 +10,9 @@ Pure-Kotlin core for the nfc-emv-toolkit. Lives in `commonMain` and ships with n
 | `io.github.a7asoft.nfcemv.tlv.internal` | Reader cursor, tag/length/node decoders, padding skipper. Internal — do not depend on these symbols. |
 | `io.github.a7asoft.nfcemv.validation` | Luhn check (this milestone) |
 | `io.github.a7asoft.nfcemv.extract` | PAN, Track 2, ServiceCode (this milestone) |
+| `io.github.a7asoft.nfcemv.emv` | EMV tag dictionary (this milestone) |
 
-Future packages (later issues): `emv` (tag dictionary), `brand` (AID + BIN brand resolution), `extract` (PAN, Track2, expiry), `validation` (Luhn, format checks).
+Future packages (later issues): `brand` (AID + BIN brand resolution), `extract` (PAN, Track2, expiry), `validation` (Luhn, format checks).
 
 ## BER-TLV decoder — quickstart
 
@@ -165,6 +166,25 @@ when (val result = Track2.parse(tag57Bytes)) {
 ```
 
 `Track2.toString` masks the PAN and reports only the discretionary length. Two-digit expiry years are interpreted as 21st century (`YY` ⇒ `20YY`).
+
+## EMV tag dictionary
+
+Look up human-readable metadata for an EMV tag:
+
+```kotlin
+import io.github.a7asoft.nfcemv.emv.EmvTags
+import io.github.a7asoft.nfcemv.tlv.Tag
+
+val info = EmvTags.lookup(Tag.fromHex("9F26"))
+// info.name           — "Application Cryptogram"
+// info.format         — EmvTagFormat.B
+// info.length         — EmvTagLength.Fixed(8)
+// info.sensitivity    — TagSensitivity.PCI
+```
+
+`EmvTags.lookup` returns `null` for tags not in the dictionary. Use `EmvTags.all` to enumerate all 27 registered entries in source order. Sensitivity is a binary `PCI` / `PUBLIC` flag; `PCI` covers PAN, Track 2, cryptograms, signed dynamic data, IAD, and the cardholder-data trio (name, expiry, sequence number).
+
+Names and metadata are hand-curated from EMV Book 3 / Book 4 / contactless kernels C-2..C-7. Descriptions are paraphrased; no third-party listing has been copied verbatim.
 
 ## Tests
 

--- a/shared/src/commonMain/kotlin/io/github/a7asoft/nfcemv/emv/EmvTagFormat.kt
+++ b/shared/src/commonMain/kotlin/io/github/a7asoft/nfcemv/emv/EmvTagFormat.kt
@@ -1,0 +1,21 @@
+package io.github.a7asoft.nfcemv.emv
+
+/**
+ * EMV data-element format codes per Book 3 §4.3 and Book 4 §A.5.
+ *
+ * - [N]  Numeric digits packed two per byte (BCD), high-nibble first; the
+ *   field is right-padded with leading-zero nibbles when shorter than the
+ *   declared length. Examples: tag 5F2A (currency), 9F02 (amount).
+ * - [AN] Alphanumeric ASCII as defined by ISO/IEC 8859-1, one character
+ *   per byte. Examples: tag 50 (label), 5F20 (cardholder name).
+ * - [B]  Raw binary bytes, opaque to the dictionary. Examples: tag 4F
+ *   (AID), 82 (AIP), 9F26 (ARQC).
+ * - [CN] Compressed numeric: BCD nibbles like [N] but with `'F'` (`0x0F`)
+ *   nibble padding when the value's nibble count is odd. Examples:
+ *   tag 5A (PAN).
+ *
+ * EMV's full notation also includes `ans` and `var.` variants. This
+ * dictionary collapses them to [AN] and either [B] or `Variable` length
+ * respectively; that's enough for the lookup-only use case.
+ */
+public enum class EmvTagFormat { N, AN, B, CN }

--- a/shared/src/commonMain/kotlin/io/github/a7asoft/nfcemv/emv/EmvTagInfo.kt
+++ b/shared/src/commonMain/kotlin/io/github/a7asoft/nfcemv/emv/EmvTagInfo.kt
@@ -1,0 +1,18 @@
+package io.github.a7asoft.nfcemv.emv
+
+import io.github.a7asoft.nfcemv.tlv.Tag
+
+/**
+ * Metadata for a single EMV BER-TLV tag.
+ *
+ * Looked up via [EmvTags.lookup]. Entries are hand-curated from EMV
+ * Book 3 / Book 4 / contactless kernels C-2..C-7; descriptions are
+ * paraphrased, not copied from any third-party listing.
+ */
+public data class EmvTagInfo(
+    val tag: Tag,
+    val name: String,
+    val format: EmvTagFormat,
+    val length: EmvTagLength,
+    val sensitivity: TagSensitivity,
+)

--- a/shared/src/commonMain/kotlin/io/github/a7asoft/nfcemv/emv/EmvTagLength.kt
+++ b/shared/src/commonMain/kotlin/io/github/a7asoft/nfcemv/emv/EmvTagLength.kt
@@ -1,0 +1,29 @@
+package io.github.a7asoft.nfcemv.emv
+
+/**
+ * Expected length of a tag's value field, in bytes.
+ *
+ * - [Fixed] when the spec mandates an exact byte count (e.g. tag 9F26
+ *   ARQC = 8 bytes, tag 82 AIP = 2 bytes).
+ * - [Variable] when the spec gives an upper bound and the actual length
+ *   varies card-by-card (e.g. tag 50 label up to 16 bytes, tag 84 DF
+ *   name up to 16 bytes, tag 8C CDOL1 up to 252 bytes).
+ *
+ * Both variants enforce a positive byte count at construction; a zero
+ * or negative spec'd length is a programming error and surfaces as
+ * [IllegalArgumentException].
+ */
+public sealed interface EmvTagLength {
+
+    public data class Fixed(val bytes: Int) : EmvTagLength {
+        init {
+            require(bytes > 0) { "Fixed tag length must be positive, was $bytes" }
+        }
+    }
+
+    public data class Variable(val maxBytes: Int) : EmvTagLength {
+        init {
+            require(maxBytes > 0) { "Variable tag max length must be positive, was $maxBytes" }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/io/github/a7asoft/nfcemv/emv/EmvTags.kt
+++ b/shared/src/commonMain/kotlin/io/github/a7asoft/nfcemv/emv/EmvTags.kt
@@ -1,0 +1,68 @@
+package io.github.a7asoft.nfcemv.emv
+
+import io.github.a7asoft.nfcemv.tlv.Tag
+
+/**
+ * Static dictionary mapping `Tag` values to their EMV metadata.
+ *
+ * Entries are sourced from EMV Book 3 / Book 4 / contactless kernel
+ * specifications C-2 through C-7. Descriptions are paraphrased; no
+ * third-party listing has been copied verbatim.
+ *
+ * Lookup is O(1) via an internal `Map<Tag, EmvTagInfo>` precomputed at
+ * class-init. [all] returns the entries in source order for callers
+ * that need to enumerate.
+ *
+ * Unknown tags return `null` from [lookup]. Callers that need an
+ * augmented dictionary (e.g. issuer-specific extensions) should
+ * maintain their own map and consult it before falling back to this
+ * one — the toolkit does not provide a plug-in / merge mechanism in
+ * this milestone.
+ */
+public object EmvTags {
+
+    /** Returns the metadata for [tag], or `null` if no entry is registered. */
+    public fun lookup(tag: Tag): EmvTagInfo? = byTag[tag]
+
+    /** All registered entries, in source order. */
+    public val all: List<EmvTagInfo> = listOf(
+        EmvTagInfo(Tag.fromHex("4F"),   "Application Identifier (AID)",                EmvTagFormat.B,  EmvTagLength.Variable(16),  TagSensitivity.PUBLIC),
+        EmvTagInfo(Tag.fromHex("50"),   "Application Label",                           EmvTagFormat.AN, EmvTagLength.Variable(16),  TagSensitivity.PUBLIC),
+        EmvTagInfo(Tag.fromHex("57"),   "Track 2 Equivalent Data",                     EmvTagFormat.B,  EmvTagLength.Variable(19),  TagSensitivity.PCI),
+        EmvTagInfo(Tag.fromHex("5A"),   "Application Primary Account Number (PAN)",    EmvTagFormat.CN, EmvTagLength.Variable(10),  TagSensitivity.PCI),
+        EmvTagInfo(Tag.fromHex("5F20"), "Cardholder Name",                             EmvTagFormat.AN, EmvTagLength.Variable(26),  TagSensitivity.PCI),
+        EmvTagInfo(Tag.fromHex("5F24"), "Application Expiration Date (YYMMDD)",        EmvTagFormat.N,  EmvTagLength.Fixed(3),      TagSensitivity.PCI),
+        // why: PCI DSS v4.0 §3 does not enumerate Effective Date as Cardholder
+        // Data, but combined with the PAN it narrows an attacker's window for
+        // derived attacks; we err on the conservative side and flag PCI.
+        EmvTagInfo(Tag.fromHex("5F25"), "Application Effective Date (YYMMDD)",         EmvTagFormat.N,  EmvTagLength.Fixed(3),      TagSensitivity.PCI),
+        EmvTagInfo(Tag.fromHex("5F28"), "Issuer Country Code (ISO 3166-1 numeric)",    EmvTagFormat.N,  EmvTagLength.Fixed(2),      TagSensitivity.PUBLIC),
+        EmvTagInfo(Tag.fromHex("5F2A"), "Transaction Currency Code (ISO 4217 numeric)",EmvTagFormat.N,  EmvTagLength.Fixed(2),      TagSensitivity.PUBLIC),
+        EmvTagInfo(Tag.fromHex("5F2D"), "Language Preference (ISO 639-1 codes)",       EmvTagFormat.AN, EmvTagLength.Variable(8),   TagSensitivity.PUBLIC),
+        EmvTagInfo(Tag.fromHex("5F34"), "Application PAN Sequence Number",             EmvTagFormat.N,  EmvTagLength.Fixed(1),      TagSensitivity.PCI),
+        EmvTagInfo(Tag.fromHex("82"),   "Application Interchange Profile (AIP)",       EmvTagFormat.B,  EmvTagLength.Fixed(2),      TagSensitivity.PUBLIC),
+        EmvTagInfo(Tag.fromHex("84"),   "Dedicated File (DF) Name",                    EmvTagFormat.B,  EmvTagLength.Variable(16),  TagSensitivity.PUBLIC),
+        EmvTagInfo(Tag.fromHex("8C"),   "CDOL1 (Card Risk Management DOL 1)",          EmvTagFormat.B,  EmvTagLength.Variable(252), TagSensitivity.PUBLIC),
+        EmvTagInfo(Tag.fromHex("8D"),   "CDOL2 (Card Risk Management DOL 2)",          EmvTagFormat.B,  EmvTagLength.Variable(252), TagSensitivity.PUBLIC),
+        EmvTagInfo(Tag.fromHex("94"),   "Application File Locator (AFL)",              EmvTagFormat.B,  EmvTagLength.Variable(252), TagSensitivity.PUBLIC),
+        EmvTagInfo(Tag.fromHex("9F02"), "Amount, Authorised (Numeric)",                EmvTagFormat.N,  EmvTagLength.Fixed(6),      TagSensitivity.PUBLIC),
+        EmvTagInfo(Tag.fromHex("9F10"), "Issuer Application Data (IAD)",               EmvTagFormat.B,  EmvTagLength.Variable(32),  TagSensitivity.PCI),
+        EmvTagInfo(Tag.fromHex("9F12"), "Application Preferred Name",                  EmvTagFormat.AN, EmvTagLength.Variable(16),  TagSensitivity.PUBLIC),
+        EmvTagInfo(Tag.fromHex("9F26"), "Application Cryptogram",                      EmvTagFormat.B,  EmvTagLength.Fixed(8),      TagSensitivity.PCI),
+        EmvTagInfo(Tag.fromHex("9F27"), "Cryptogram Information Data (CID)",           EmvTagFormat.B,  EmvTagLength.Fixed(1),      TagSensitivity.PUBLIC),
+        EmvTagInfo(Tag.fromHex("9F36"), "Application Transaction Counter (ATC)",       EmvTagFormat.B,  EmvTagLength.Fixed(2),      TagSensitivity.PUBLIC),
+        EmvTagInfo(Tag.fromHex("9F37"), "Unpredictable Number",                        EmvTagFormat.B,  EmvTagLength.Fixed(4),      TagSensitivity.PUBLIC),
+        EmvTagInfo(Tag.fromHex("9F4B"), "Signed Dynamic Application Data",             EmvTagFormat.B,  EmvTagLength.Variable(248), TagSensitivity.PCI),
+        // why: tag 9F6B is multiplexed across kernels — Mastercard C-2 uses it
+        // as Track 2 Data (PCI), Visa C-3 uses it as Card CVM Limit (PUBLIC,
+        // 6-byte numeric). This dictionary only registers the C-2 mapping
+        // (the toolkit's primary contactless target); a future kernel-scoped
+        // overlay is tracked as out-of-scope. Callers decoding under C-3 MUST
+        // NOT rely on this entry.
+        EmvTagInfo(Tag.fromHex("9F6B"), "Track 2 Data (Mastercard kernel C-2)",        EmvTagFormat.B,  EmvTagLength.Variable(19),  TagSensitivity.PCI),
+        EmvTagInfo(Tag.fromHex("9F6C"), "Card Transaction Qualifiers (CTQ)",           EmvTagFormat.B,  EmvTagLength.Fixed(2),      TagSensitivity.PUBLIC),
+        EmvTagInfo(Tag.fromHex("BF0C"), "FCI Issuer Discretionary Data",               EmvTagFormat.B,  EmvTagLength.Variable(222), TagSensitivity.PUBLIC),
+    )
+
+    private val byTag: Map<Tag, EmvTagInfo> = all.associateBy { it.tag }
+}

--- a/shared/src/commonMain/kotlin/io/github/a7asoft/nfcemv/emv/TagSensitivity.kt
+++ b/shared/src/commonMain/kotlin/io/github/a7asoft/nfcemv/emv/TagSensitivity.kt
@@ -1,0 +1,20 @@
+package io.github.a7asoft.nfcemv.emv
+
+/**
+ * Two-level binary classification used by the tag dictionary and any
+ * downstream extractor.
+ *
+ * - [PCI] — value bytes are PCI DSS Cardholder Data (PAN, expiry, name,
+ *   sequence number) or Sensitive Authentication Data
+ *   (full Track 2, cryptograms, signed dynamic data, issuer-application
+ *   data with cryptographic state). NEVER log, persist, or transmit
+ *   raw; route through a typed extractor with masking on `toString`.
+ * - [PUBLIC] — value bytes are operational metadata (AIDs, labels,
+ *   country / currency / language codes, AIP, AFL, CDOLs, ATC, UN,
+ *   transaction amount, CTQ, CID, FCI templates). Safe to log raw.
+ *
+ * The dichotomy is deliberately binary; a finer grain (e.g. `Cryptogram`,
+ * `CardholderData`, `OperationalPublic`) can be layered later without
+ * breaking callers that only check `== PCI`.
+ */
+public enum class TagSensitivity { PCI, PUBLIC }

--- a/shared/src/commonTest/kotlin/io/github/a7asoft/nfcemv/emv/EmvTagsTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/a7asoft/nfcemv/emv/EmvTagsTest.kt
@@ -1,0 +1,281 @@
+package io.github.a7asoft.nfcemv.emv
+
+import io.github.a7asoft.nfcemv.tlv.Tag
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class EmvTagsTest {
+
+    // ---- EmvTagFormat ----
+
+    @Test
+    fun `EmvTagFormat enumerates the four EMV format codes`() {
+        assertEquals(
+            setOf(EmvTagFormat.N, EmvTagFormat.AN, EmvTagFormat.B, EmvTagFormat.CN),
+            EmvTagFormat.entries.toSet(),
+        )
+    }
+
+    // ---- EmvTagLength ----
+
+    @Test
+    fun `EmvTagLength Fixed exposes the byte count`() {
+        assertEquals(8, EmvTagLength.Fixed(8).bytes)
+    }
+
+    @Test
+    fun `EmvTagLength Variable exposes the maximum byte count`() {
+        assertEquals(252, EmvTagLength.Variable(252).maxBytes)
+    }
+
+    @Test
+    fun `EmvTagLength Fixed rejects zero byte count`() {
+        assertFailsWith<IllegalArgumentException> { EmvTagLength.Fixed(0) }
+    }
+
+    @Test
+    fun `EmvTagLength Fixed rejects negative byte count`() {
+        assertFailsWith<IllegalArgumentException> { EmvTagLength.Fixed(-1) }
+    }
+
+    @Test
+    fun `EmvTagLength Variable rejects zero maximum`() {
+        assertFailsWith<IllegalArgumentException> { EmvTagLength.Variable(0) }
+    }
+
+    @Test
+    fun `EmvTagLength Variable rejects negative maximum`() {
+        assertFailsWith<IllegalArgumentException> { EmvTagLength.Variable(-5) }
+    }
+
+    // ---- TagSensitivity ----
+
+    @Test
+    fun `TagSensitivity has exactly two values`() {
+        assertEquals(setOf(TagSensitivity.PCI, TagSensitivity.PUBLIC), TagSensitivity.entries.toSet())
+    }
+
+    // ---- EmvTagInfo construction ----
+
+    @Test
+    fun `EmvTagInfo carries the supplied tag`() {
+        val info = sampleInfo()
+        assertEquals(Tag.fromHex("9F26"), info.tag)
+    }
+
+    @Test
+    fun `EmvTagInfo carries the supplied name`() {
+        assertEquals("Application Cryptogram", sampleInfo().name)
+    }
+
+    @Test
+    fun `EmvTagInfo carries the supplied format`() {
+        assertEquals(EmvTagFormat.B, sampleInfo().format)
+    }
+
+    @Test
+    fun `EmvTagInfo carries the supplied length`() {
+        assertEquals(EmvTagLength.Fixed(8), sampleInfo().length)
+    }
+
+    @Test
+    fun `EmvTagInfo carries the supplied sensitivity`() {
+        assertEquals(TagSensitivity.PCI, sampleInfo().sensitivity)
+    }
+
+    // ---- EmvTags lookup ----
+
+    @Test
+    fun `lookup returns null for an unknown tag`() {
+        assertNull(EmvTags.lookup(Tag.fromHex("99")))
+    }
+
+    @Test
+    fun `lookup returns null for unknown 0xFF tag`() {
+        assertNull(EmvTags.lookup(Tag.fromHex("FF")))
+    }
+
+    @Test
+    fun `lookup returns null for unknown 0x9F99 tag`() {
+        assertNull(EmvTags.lookup(Tag.fromHex("9F99")))
+    }
+
+    @Test
+    fun `lookup returns null for unknown 0xBFAA tag`() {
+        assertNull(EmvTags.lookup(Tag.fromHex("BFAA")))
+    }
+
+    @Test
+    fun `lookup returns the ARQC entry for tag 9F26`() {
+        val info = assertNotNull(EmvTags.lookup(Tag.fromHex("9F26")))
+        assertEquals("Application Cryptogram", info.name)
+        assertEquals(EmvTagFormat.B, info.format)
+        assertEquals(EmvTagLength.Fixed(8), info.length)
+        assertEquals(TagSensitivity.PCI, info.sensitivity)
+    }
+
+    // ---- Dictionary structural invariants ----
+
+    @Test
+    fun `dictionary contains exactly 27 entries`() {
+        assertEquals(27, EmvTags.all.size)
+    }
+
+    @Test
+    fun `dictionary has no duplicate tag entries`() {
+        val tags = EmvTags.all.map { it.tag }
+        assertEquals(tags.size, tags.toSet().size)
+    }
+
+    @Test
+    fun `every dictionary entry has a non-blank name`() {
+        val blanks = EmvTags.all.filter { it.name.isBlank() }
+        assertEquals(emptyList(), blanks, "found entries with blank names")
+    }
+
+    @Test
+    fun `lookup resolves every registered entry by its tag`() {
+        val mismatches = EmvTags.all.filter { entry -> EmvTags.lookup(entry.tag) != entry }
+        assertEquals(emptyList(), mismatches, "lookup failed for the listed entries")
+    }
+
+    // ---- Spot checks (one entry-shape per test, three field assertions per test) ----
+    // Bundled-three-field assertions are treated as one "the entry's shape" concept;
+    // if any field is wrong, the entire entry needs revision against EMV Book 3 Annex A.
+
+    @Test
+    fun `tag 5A is the PAN with CN format Variable 10 and PCI sensitivity`() {
+        val pan = assertNotNull(EmvTags.lookup(Tag.fromHex("5A")))
+        assertEquals(EmvTagFormat.CN, pan.format)
+        assertEquals(EmvTagLength.Variable(10), pan.length)
+        assertEquals(TagSensitivity.PCI, pan.sensitivity)
+    }
+
+    @Test
+    fun `tag 4F is the AID with B format Variable 16 and PUBLIC sensitivity`() {
+        val aid = assertNotNull(EmvTags.lookup(Tag.fromHex("4F")))
+        assertEquals(EmvTagFormat.B, aid.format)
+        assertEquals(EmvTagLength.Variable(16), aid.length)
+        assertEquals(TagSensitivity.PUBLIC, aid.sensitivity)
+    }
+
+    @Test
+    fun `tag 9F02 amount has N format Fixed 6 and PUBLIC sensitivity`() {
+        val amount = assertNotNull(EmvTags.lookup(Tag.fromHex("9F02")))
+        assertEquals(EmvTagFormat.N, amount.format)
+        assertEquals(EmvTagLength.Fixed(6), amount.length)
+        assertEquals(TagSensitivity.PUBLIC, amount.sensitivity)
+    }
+
+    @Test
+    fun `tag 50 application label has AN format`() {
+        val label = assertNotNull(EmvTags.lookup(Tag.fromHex("50")))
+        assertEquals(EmvTagFormat.AN, label.format)
+    }
+
+    // ---- Distribution invariants ----
+
+    @Test
+    fun `at least one entry uses EmvTagFormat N`() {
+        assertTrue(EmvTags.all.any { it.format == EmvTagFormat.N }, "no N entry")
+    }
+
+    @Test
+    fun `at least one entry uses EmvTagFormat AN`() {
+        assertTrue(EmvTags.all.any { it.format == EmvTagFormat.AN }, "no AN entry")
+    }
+
+    @Test
+    fun `at least one entry uses EmvTagFormat B`() {
+        assertTrue(EmvTags.all.any { it.format == EmvTagFormat.B }, "no B entry")
+    }
+
+    @Test
+    fun `at least one entry uses EmvTagFormat CN`() {
+        assertTrue(EmvTags.all.any { it.format == EmvTagFormat.CN }, "no CN entry")
+    }
+
+    @Test
+    fun `at least one entry is flagged TagSensitivity PCI`() {
+        assertTrue(EmvTags.all.any { it.sensitivity == TagSensitivity.PCI }, "no PCI entry")
+    }
+
+    @Test
+    fun `at least one entry is flagged TagSensitivity PUBLIC`() {
+        assertTrue(EmvTags.all.any { it.sensitivity == TagSensitivity.PUBLIC }, "no PUBLIC entry")
+    }
+
+    @Test
+    fun `at least one entry uses EmvTagLength Fixed`() {
+        assertTrue(EmvTags.all.any { it.length is EmvTagLength.Fixed }, "no Fixed-length entry")
+    }
+
+    @Test
+    fun `at least one entry uses EmvTagLength Variable`() {
+        assertTrue(EmvTags.all.any { it.length is EmvTagLength.Variable }, "no Variable-length entry")
+    }
+
+    // ---- PCI bucket coverage (one test per anchor tag) ----
+
+    @Test
+    fun `tag 5A PAN is in the PCI bucket`() {
+        val pan = assertNotNull(EmvTags.lookup(Tag.fromHex("5A")))
+        assertEquals(TagSensitivity.PCI, pan.sensitivity)
+    }
+
+    @Test
+    fun `tag 57 Track 2 is in the PCI bucket`() {
+        val t2 = assertNotNull(EmvTags.lookup(Tag.fromHex("57")))
+        assertEquals(TagSensitivity.PCI, t2.sensitivity)
+    }
+
+    @Test
+    fun `tag 9F26 ARQC is in the PCI bucket`() {
+        val arqc = assertNotNull(EmvTags.lookup(Tag.fromHex("9F26")))
+        assertEquals(TagSensitivity.PCI, arqc.sensitivity)
+    }
+
+    @Test
+    fun `tag 9F4B Signed Dynamic Application Data is in the PCI bucket`() {
+        val sdad = assertNotNull(EmvTags.lookup(Tag.fromHex("9F4B")))
+        assertEquals(TagSensitivity.PCI, sdad.sensitivity)
+    }
+
+    @Test
+    fun `tag 9F6B Track 2 Mastercard kernel C-2 is in the PCI bucket`() {
+        val t2mc = assertNotNull(EmvTags.lookup(Tag.fromHex("9F6B")))
+        assertEquals(TagSensitivity.PCI, t2mc.sensitivity)
+    }
+
+    // ---- PUBLIC bucket coverage (one test per anchor tag) ----
+
+    @Test
+    fun `tag 4F AID is in the PUBLIC bucket`() {
+        val aid = assertNotNull(EmvTags.lookup(Tag.fromHex("4F")))
+        assertEquals(TagSensitivity.PUBLIC, aid.sensitivity)
+    }
+
+    @Test
+    fun `tag 82 AIP is in the PUBLIC bucket`() {
+        val aip = assertNotNull(EmvTags.lookup(Tag.fromHex("82")))
+        assertEquals(TagSensitivity.PUBLIC, aip.sensitivity)
+    }
+
+    @Test
+    fun `tag 94 AFL is in the PUBLIC bucket`() {
+        val afl = assertNotNull(EmvTags.lookup(Tag.fromHex("94")))
+        assertEquals(TagSensitivity.PUBLIC, afl.sensitivity)
+    }
+
+    private fun sampleInfo(): EmvTagInfo = EmvTagInfo(
+        tag = Tag.fromHex("9F26"),
+        name = "Application Cryptogram",
+        format = EmvTagFormat.B,
+        length = EmvTagLength.Fixed(8),
+        sensitivity = TagSensitivity.PCI,
+    )
+}


### PR DESCRIPTION
## Summary

Promotes the EMV tag dictionary (issue #3) to \`main\`. Single-commit release branch built clean off \`main\`.

## What changes vs main

- **New**: package \`io.github.a7asoft.nfcemv.emv\` with \`EmvTagFormat\` enum, \`EmvTagLength\` sealed (Fixed / Variable), \`TagSensitivity\` enum, \`EmvTagInfo\` data class, and \`EmvTags\` lookup object.
- **27 entries** covering EMV Book 3 / Book 4 / contactless kernels C-2..C-7 — 12 PCI / 15 PUBLIC.
- **Updated**: \`shared/README.md\` with a "EMV tag dictionary" section.
- **Updated**: \`CHANGELOG.md\` Unreleased entry under #3.
- **+1 test file / 42 tests** in \`EmvTagsTest\` — distribution invariants, anchor tests per PCI / PUBLIC bucket, exact-form spot checks for tags 5A / 4F / 9F02 / 9F26 / 50.

## Properties pinned

- O(1) lookup via private \`Map<Tag, EmvTagInfo>\` precomputed at object init.
- Names paraphrased; no third-party listing copied verbatim.
- \`TagSensitivity.PCI\` flag explicitly forbids logging raw value bytes (downstream extractors gate on \`== PCI\`).
- \`5F25\` (Effective Date) conservatively PCI; rationale documented inline (PCI DSS does not enumerate it as Cardholder Data, but combined with PAN narrows attacker windows).
- \`9F6B\` mapped to Mastercard kernel C-2 only (\"Track 2 Data\" PCI); Visa C-3 redefines the same hex as \"Card CVM Limit\" (PUBLIC numeric) — this dictionary does not disambiguate by kernel, callers under C-3 must not rely on this entry. Rationale documented inline.

## Test plan
- [x] \`./gradlew :shared:allTests\` clean
- [x] \`./gradlew :composeApp:assembleDebug\` clean
- [ ] CI green
- [ ] Tag \`v0.1.4\` once merged