### PR TITLE
release: EmvCard model + EmvParser entry point (v0.1.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented here. The format follows 
 
 ## [Unreleased]
 
+### Added — EmvCard model + EmvParser entry point (#8)
+- `EmvCard` data class composing every parser shipped so far: `pan: Pan`, `expiry: YearMonth` (kotlinx.datetime), `cardholderName: String?`, `brand: EmvBrand`, `applicationLabel: String?`, `track2: Track2?`, `aid: Aid`.
+- `EmvParser.parse(apduResponses: List<ByteArray>): EmvCardResult` (sealed `Ok` / `Err(EmvCardError)`) and `EmvParser.parseOrThrow` for the throw form. Mirrors `Pan.parse` / `parseOrThrow` and `Track2.parse` / `parseOrThrow`.
+- `EmvCardError` sealed catalogue: `EmptyInput`, `TlvDecodeFailed(cause: TlvError)`, `MissingRequiredTag(tagHex)`, `PanRejected(cause: PanError)`, `Track2Rejected(cause: Track2Error)`, `InvalidExpiryFormat(nibbleCount)`, `InvalidExpiryMonth(month)`, `InvalidAid(byteCount)`. Errors carry only structural metadata; raw bytes never appear.
+- Required tags (`4F`, `5A`, `5F24`) and optional tags (`5F20`, `50`, `57`) are extracted via per-format helpers in `extract/internal/`; PAN segment delegates to `Pan.parse`, Track 2 delegates to `Track2.parse`, brand resolution delegates to `BrandResolver.resolveBrand`. TLV decoding uses `Strictness.Lenient` so cards that emit non-minimal length encodings still parse.
+- `EmvCard.toString` overrides the data class default to mask sensitive fields: PAN through `Pan.toString`, Track 2 through `Track2.toString`, and cardholder name as a length-only placeholder (`<N chars>`). Direct `cardholderName` accessor still returns the raw String — caller MUST NOT log the EmvCard whole. A future `CardholderName` value-class wrapper is tracked separately.
+- Tag `5A` PAN BCD validation: malformed nibbles (`0xA..0xE` in any position; `0xF` in a non-trailing position) surface as the typed `EmvCardError.MalformedPanNibble(offset)` BEFORE reaching `Pan.parse`, so the diagnostic reports the actual offending nibble offset rather than a derived character index.
+- Tags `5F20` and `50` decode as ISO-8859-1 (was UTF-8); cardholder names like `MÜLLER` (Latin-1 `0xDC`) round-trip correctly.
+- `extractAid` validates byte length BEFORE copying the value, eliminating the wasted defensive copy on the error path.
+- 1,000-iteration deterministic property fuzz pinning the parser invariant: every `List<ByteArray>` resolves to a typed `EmvCardResult`, with no other exception escaping (mirrors `TlvDecoderFuzzTest` and `TrackEncoderFuzzTest`).
+- Multi-APDU integration test: `EmvParser.parse` correctly merges fields across multiple `ByteArray` responses.
+- `CENTURY_OFFSET = 2000` two-digit-year mapping is documented as a deliberate v0.1.x deviation from EMV (which leaves century interpretation to the kernel) and pinned by regression tests at YY=00 and YY=99.
+- `EmvParser` KDoc explicitly enumerates out-of-scope behaviors: PSE/PPSE flow, multi-AID with `87` priority, `9F6B` Mastercard Track 2 fallback, PAN agreement between `5A` and `57`, caller-overridable `Strictness`. Each is tracked separately for v0.2.x or later.
+
 ### Added — BER-TLV decoder (#1)
 - `Tag` value class (`@JvmInline`) backed by a packed `Long`. Supports 1–4 byte tags per ISO/IEC 8825-1.
 - `TagClass` enum (universal / application / context-specific / private).

--- a/shared/README.md
+++ b/shared/README.md
@@ -211,6 +211,35 @@ Resolution layers:
 
 The AID directory ships 23 entries across 9 brands; the BIN table covers the same 9 plus broad UnionPay catch-all. Both are paraphrased from EMVCo and ISO/IEC 7816-5 sources.
 
+## Top-level EMV parser
+
+Compose a card snapshot from a list of APDU response data fields:
+
+```kotlin
+import io.github.a7asoft.nfcemv.extract.EmvParser
+import io.github.a7asoft.nfcemv.extract.EmvCardResult
+
+val responses: List<ByteArray> = collectApduResponses() // SW1 SW2 already stripped
+
+when (val result = EmvParser.parse(responses)) {
+    is EmvCardResult.Ok -> {
+        val card = result.card
+        // card.pan        — io.github.a7asoft.nfcemv.extract.Pan (masked toString)
+        // card.expiry     — kotlinx.datetime.YearMonth
+        // card.brand      — io.github.a7asoft.nfcemv.brand.EmvBrand
+        // card.aid        — io.github.a7asoft.nfcemv.brand.Aid
+        // card.track2     — io.github.a7asoft.nfcemv.extract.Track2? (nullable)
+        // card.cardholderName — String? (PCI-scoped — see KDoc)
+        // card.applicationLabel — String? (operational metadata, safe to log)
+    }
+    is EmvCardResult.Err -> reportRefusal(result.error)
+}
+```
+
+Required tags: `4F` AID, `5A` PAN, `5F24` expiry. Optional: `5F20` cardholder name, `50` application label, `57` Track 2. Brand is resolved via `BrandResolver.resolveBrand(aid, pan)`.
+
+`EmvCard.toString` masks the PAN, Track 2 (PAN + discretionary), and cardholder name (length-only placeholder); other fields render raw.
+
 ## Tests
 
 179 tests on `commonMain` cover happy paths, all error variants, the EMV padding behavior, the documented X.690 deviation, fuzz over 10,000 random buffers (strict + lenient), OOM-resistance regression, PCI-safety regressions for tags `5A`, `57`, and `9F26`, encoder round-trip fixtures, 5,000-iteration encoder fuzz, encoder PCI-safety regressions. Run with:

--- a/shared/src/commonMain/kotlin/io/github/a7asoft/nfcemv/extract/EmvCard.kt
+++ b/shared/src/commonMain/kotlin/io/github/a7asoft/nfcemv/extract/EmvCard.kt
@@ -1,0 +1,52 @@
+package io.github.a7asoft.nfcemv.extract
+
+import io.github.a7asoft.nfcemv.brand.Aid
+import io.github.a7asoft.nfcemv.brand.EmvBrand
+import kotlinx.datetime.YearMonth
+
+/**
+ * Top-level EMV card snapshot composed from APDU responses by
+ * [EmvParser.parse].
+ *
+ * Required fields (`pan`, `expiry`, `aid`) are non-null; optional
+ * fields (`cardholderName`, `applicationLabel`, `track2`) are nullable
+ * and reflect whether the corresponding TLV tag was present in the
+ * input. `brand` is computed via `BrandResolver.resolveBrand(aid, pan)`
+ * and is therefore always one of the registered [EmvBrand] values
+ * including [EmvBrand.UNKNOWN].
+ *
+ * The class is a `data class` (per the issue spec) for `componentN` /
+ * `copy` ergonomics, but `toString` is overridden to mask sensitive
+ * fields:
+ * - `pan` is rendered through [Pan.toString], which masks per PCI DSS
+ *   Req 3.4 first-6 + last-4 (delegated).
+ * - `cardholderName` is rendered as `<N chars>` — the length only,
+ *   never the value, because cardholder name is PCI Cardholder Data.
+ * - `track2` is rendered through [Track2.toString], which masks both
+ *   the embedded PAN and the discretionary bytes (delegated).
+ * - `applicationLabel`, `brand`, `expiry`, `aid` are rendered raw —
+ *   non-PCI operational metadata.
+ *
+ * IMPORTANT: the [cardholderName] property accessor returns the raw
+ * String. Direct field access bypasses the `toString` mask. Callers
+ * MUST NOT pass an `EmvCard` instance to a generic logger that calls
+ * `toString` recursively over all fields, and MUST NOT log
+ * `card.cardholderName` directly. A future `CardholderName` value-class
+ * wrapper will harden this surface (tracked separately).
+ */
+public data class EmvCard internal constructor(
+    public val pan: Pan,
+    public val expiry: YearMonth,
+    public val cardholderName: String?,
+    public val brand: EmvBrand,
+    public val applicationLabel: String?,
+    public val track2: Track2?,
+    public val aid: Aid,
+) {
+    override fun toString(): String =
+        "EmvCard(pan=$pan, expiry=$expiry, cardholderName=${maskCardholderName(cardholderName)}, " +
+            "brand=$brand, applicationLabel=$applicationLabel, track2=$track2, aid=$aid)"
+}
+
+private fun maskCardholderName(name: String?): String =
+    if (name == null) "null" else "<${name.length} chars>"

--- a/shared/src/commonMain/kotlin/io/github/a7asoft/nfcemv/extract/EmvCardError.kt
+++ b/shared/src/commonMain/kotlin/io/github/a7asoft/nfcemv/extract/EmvCardError.kt
@@ -1,0 +1,67 @@
+package io.github.a7asoft.nfcemv.extract
+
+import io.github.a7asoft.nfcemv.tlv.TlvError
+
+/**
+ * A typed reason `EmvParser.parse` rejected an APDU response stream.
+ *
+ * Variants carry only structural metadata (offsets, counts, sub-error
+ * references). They never embed raw nibbles, PAN digits, cardholder
+ * name, or discretionary bytes — `MissingRequiredTag.tagHex` is the
+ * static tag identifier (e.g. `"5A"`), not card-derived data.
+ */
+public sealed interface EmvCardError {
+
+    /** Caller passed an empty `List<ByteArray>` to [EmvParser.parse]. */
+    public data object EmptyInput : EmvCardError
+
+    /**
+     * One of the input byte arrays failed BER-TLV decoding. The wrapped
+     * [TlvError] carries the structural offset; no value bytes are
+     * embedded.
+     */
+    public data class TlvDecodeFailed(val cause: TlvError) : EmvCardError
+
+    /**
+     * A tag the EmvCard contract requires (`4F` AID, `5A` PAN, or
+     * `5F24` expiry) was not present in any of the decoded TLV trees.
+     * [tagHex] is the static tag identifier as uppercase hex.
+     */
+    public data class MissingRequiredTag(val tagHex: String) : EmvCardError
+
+    /** Tag `5A` PAN failed `Pan.parse`. The wrapped [PanError] explains why. */
+    public data class PanRejected(val cause: PanError) : EmvCardError
+
+    /**
+     * Tag `57` Track 2 was present but failed `Track2.parse`. The
+     * wrapped [Track2Error] explains why.
+     */
+    public data class Track2Rejected(val cause: Track2Error) : EmvCardError
+
+    /**
+     * Tag `5F24` expiry value did not have the expected 6-nibble
+     * `YYMMDD` shape.
+     */
+    public data class InvalidExpiryFormat(val nibbleCount: Int) : EmvCardError
+
+    /**
+     * Tag `5F24` expiry parsed to an out-of-range month (must be 1..12).
+     */
+    public data class InvalidExpiryMonth(val month: Int) : EmvCardError
+
+    /** Tag `4F` AID had a length outside the valid `5..16` byte range. */
+    public data class InvalidAid(val byteCount: Int) : EmvCardError
+
+    /**
+     * Tag `5A` PAN BCD encoding contained a malformed nibble at the
+     * given offset (any of `0xA..0xE` in any position, or `0xF` in a
+     * non-trailing position). EMV Book 3 §A.1 mandates BCD digits
+     * `0..9` with at most one trailing `F` pad nibble.
+     *
+     * Distinct from [PanRejected] (`NonDigitCharacters`): this variant
+     * fires BEFORE the unpacked digit string reaches `Pan.parse`, so
+     * the offset reported is the actual offending nibble position
+     * rather than a derived character index.
+     */
+    public data class MalformedPanNibble(val offset: Int) : EmvCardError
+}

--- a/shared/src/commonMain/kotlin/io/github/a7asoft/nfcemv/extract/EmvCardResult.kt
+++ b/shared/src/commonMain/kotlin/io/github/a7asoft/nfcemv/extract/EmvCardResult.kt
@@ -1,0 +1,16 @@
+package io.github.a7asoft.nfcemv.extract
+
+/**
+ * The outcome of `EmvParser.parse(apduResponses)`. Either `Ok` carrying
+ * a fully composed [EmvCard] or `Err` carrying a typed [EmvCardError].
+ *
+ * Mirrors `TlvParseResult`, `PanResult`, and `Track2Result` for a
+ * consistent control-flow shape across the toolkit.
+ */
+public sealed interface EmvCardResult {
+    /** Successful parse carrying the composed [EmvCard]. */
+    public data class Ok(val card: EmvCard) : EmvCardResult
+
+    /** Parse failed; see [error] for the typed reason. */
+    public data class Err(val error: EmvCardError) : EmvCardResult
+}

--- a/shared/src/commonMain/kotlin/io/github/a7asoft/nfcemv/extract/EmvParser.kt
+++ b/shared/src/commonMain/kotlin/io/github/a7asoft/nfcemv/extract/EmvParser.kt
@@ -1,0 +1,234 @@
+package io.github.a7asoft.nfcemv.extract
+
+import io.github.a7asoft.nfcemv.brand.Aid
+import io.github.a7asoft.nfcemv.brand.BrandResolver
+import io.github.a7asoft.nfcemv.extract.internal.ExtractResult
+import io.github.a7asoft.nfcemv.extract.internal.extractAid
+import io.github.a7asoft.nfcemv.extract.internal.extractApplicationLabel
+import io.github.a7asoft.nfcemv.extract.internal.extractCardholderName
+import io.github.a7asoft.nfcemv.extract.internal.extractExpiry
+import io.github.a7asoft.nfcemv.extract.internal.extractPan
+import io.github.a7asoft.nfcemv.extract.internal.extractTrack2
+import io.github.a7asoft.nfcemv.extract.internal.findFirst
+import io.github.a7asoft.nfcemv.tlv.Strictness
+import io.github.a7asoft.nfcemv.tlv.Tag
+import io.github.a7asoft.nfcemv.tlv.Tlv
+import io.github.a7asoft.nfcemv.tlv.TlvDecoder
+import io.github.a7asoft.nfcemv.tlv.TlvError
+import io.github.a7asoft.nfcemv.tlv.TlvOptions
+import io.github.a7asoft.nfcemv.tlv.TlvParseResult
+import kotlinx.datetime.YearMonth
+
+/**
+ * Top-level EMV card composer.
+ *
+ * Decodes a list of APDU response data fields (with SW1 SW2 already
+ * stripped by the transport layer), recursively searches the resulting
+ * TLV trees for the required (`4F`, `5A`, `5F24`) and optional (`5F20`,
+ * `50`, `57`) tags, decodes each via per-format extractors, and
+ * composes an [EmvCard] with the brand resolved through
+ * [BrandResolver.resolveBrand].
+ *
+ * Two API styles:
+ * - [parse] returns a sealed [EmvCardResult] (mirrors `Pan.parse`,
+ *   `Track2.parse`, `TlvDecoder.parse`).
+ * - [parseOrThrow] throws [IllegalArgumentException] on the first
+ *   detected violation.
+ *
+ * ### TLV decoding mode
+ *
+ * Hardcoded to [Strictness.Lenient]: real cards have been observed
+ * emitting non-minimal length encodings, and a strict reader would
+ * falsely reject them. Caller-overridable strictness is intentionally
+ * out of scope for v0.1.x; if a diagnostic / lab use case needs strict
+ * mode, decode externally with [TlvDecoder.parse] first and feed the
+ * result through bespoke extractors.
+ *
+ * ### Out-of-scope behaviors (deferred — caller responsibility)
+ *
+ * - **PSE / PPSE flow.** Caller MUST supply only one application's
+ *   records. Mixing record streams from multiple applications causes
+ *   `findFirst` to cross-pollinate fields between unrelated AIDs.
+ * - **Multiple AIDs / Application Priority Indicator (tag `87`).**
+ *   When more than one `4F` is present, the first DFS-order match
+ *   wins. EMV Book 1 §12.4 priority handling is not implemented.
+ * - **Tag `9F6B` Mastercard Track 2 fallback.** When tag `57` is
+ *   absent, the parser does NOT consult `9F6B`; `track2` becomes
+ *   `null`. Callers handling Mastercard contactless must rewrite
+ *   `9F6B` to `57` upstream.
+ * - **PAN agreement between `5A` and `57`.** EMV mandates the same
+ *   PAN in both; this parser does NOT cross-check. A mismatch is
+ *   silently kept (caller responsibility to verify).
+ * - **Two-digit year mapping.** Tags `5F24` (and `Track2.expiry`)
+ *   are mapped `YY ⇒ 20YY` (21st-century convention). Cards
+ *   expiring 2100+ would mis-map; out of scope for v0.1.x.
+ *
+ * Each of these has an explicit pinning test (or a documentation note)
+ * so a future implementation does not silently regress.
+ */
+public object EmvParser {
+
+    private val LENIENT: TlvOptions = TlvOptions(strictness = Strictness.Lenient)
+    private val TAG_AID = Tag.fromHex("4F")
+    private val TAG_PAN = Tag.fromHex("5A")
+    private val TAG_EXPIRY = Tag.fromHex("5F24")
+    private val TAG_CARDHOLDER = Tag.fromHex("5F20")
+    private val TAG_LABEL = Tag.fromHex("50")
+    private val TAG_TRACK2 = Tag.fromHex("57")
+
+    /**
+     * Parse [apduResponses] (each ByteArray = one APDU response data
+     * field with SW1 SW2 already stripped) into an [EmvCardResult].
+     */
+    public fun parse(apduResponses: List<ByteArray>): EmvCardResult {
+        if (apduResponses.isEmpty()) return EmvCardResult.Err(EmvCardError.EmptyInput)
+        val nodes = when (val outcome = decodeAll(apduResponses)) {
+            is DecodeOutcome.Ok -> outcome.nodes
+            is DecodeOutcome.Err -> return EmvCardResult.Err(outcome.error)
+        }
+        val required = when (val r = extractRequiredFields(nodes)) {
+            is RequiredOutcome.Ok -> r.fields
+            is RequiredOutcome.Err -> return EmvCardResult.Err(r.error)
+        }
+        val optional = when (val r = extractOptionalFields(nodes)) {
+            is OptionalOutcome.Ok -> r.fields
+            is OptionalOutcome.Err -> return EmvCardResult.Err(r.error)
+        }
+        val brand = BrandResolver.resolveBrand(aid = required.aid, pan = required.pan)
+        return EmvCardResult.Ok(
+            EmvCard(
+                pan = required.pan, expiry = required.expiry,
+                cardholderName = optional.cardholderName, brand = brand,
+                applicationLabel = optional.applicationLabel,
+                track2 = optional.track2, aid = required.aid,
+            ),
+        )
+    }
+
+    /**
+     * Parse [apduResponses] into an [EmvCard], or throw
+     * [IllegalArgumentException] on the first detected violation.
+     */
+    public fun parseOrThrow(apduResponses: List<ByteArray>): EmvCard =
+        when (val result = parse(apduResponses)) {
+            is EmvCardResult.Ok -> result.card
+            is EmvCardResult.Err -> throw IllegalArgumentException(messageFor(result.error))
+        }
+
+    // ----- private orchestrators -----
+
+    private data class RequiredFields(val aid: Aid, val pan: Pan, val expiry: YearMonth)
+
+    private data class OptionalFields(
+        val cardholderName: String?,
+        val applicationLabel: String?,
+        val track2: Track2?,
+    )
+
+    private sealed interface DecodeOutcome {
+        data class Ok(val nodes: List<Tlv>) : DecodeOutcome
+        data class Err(val error: EmvCardError) : DecodeOutcome
+    }
+
+    private sealed interface RequiredOutcome {
+        data class Ok(val fields: RequiredFields) : RequiredOutcome
+        data class Err(val error: EmvCardError) : RequiredOutcome
+    }
+
+    private sealed interface OptionalOutcome {
+        data class Ok(val fields: OptionalFields) : OptionalOutcome
+        data class Err(val error: EmvCardError) : OptionalOutcome
+    }
+
+    private fun decodeAll(apduResponses: List<ByteArray>): DecodeOutcome {
+        val collected = mutableListOf<Tlv>()
+        for (response in apduResponses) {
+            when (val parsed = TlvDecoder.parse(response, LENIENT)) {
+                is TlvParseResult.Ok -> collected.addAll(parsed.tlvs)
+                is TlvParseResult.Err -> return DecodeOutcome.Err(EmvCardError.TlvDecodeFailed(parsed.error))
+            }
+        }
+        return DecodeOutcome.Ok(collected)
+    }
+
+    private fun extractRequiredFields(nodes: List<Tlv>): RequiredOutcome {
+        val aidNode = findFirst(nodes, TAG_AID) as? Tlv.Primitive
+            ?: return RequiredOutcome.Err(EmvCardError.MissingRequiredTag("4F"))
+        val aid = when (val r = extractAid(aidNode)) {
+            is ExtractResult.Ok -> r.value
+            is ExtractResult.Err -> return RequiredOutcome.Err(r.error)
+        }
+        val panNode = findFirst(nodes, TAG_PAN) as? Tlv.Primitive
+            ?: return RequiredOutcome.Err(EmvCardError.MissingRequiredTag("5A"))
+        val pan = when (val r = extractPan(panNode)) {
+            is ExtractResult.Ok -> r.value
+            is ExtractResult.Err -> return RequiredOutcome.Err(r.error)
+        }
+        val expiryNode = findFirst(nodes, TAG_EXPIRY) as? Tlv.Primitive
+            ?: return RequiredOutcome.Err(EmvCardError.MissingRequiredTag("5F24"))
+        val expiry = when (val r = extractExpiry(expiryNode)) {
+            is ExtractResult.Ok -> r.value
+            is ExtractResult.Err -> return RequiredOutcome.Err(r.error)
+        }
+        return RequiredOutcome.Ok(RequiredFields(aid, pan, expiry))
+    }
+
+    private fun extractOptionalFields(nodes: List<Tlv>): OptionalOutcome {
+        val cardholderName = (findFirst(nodes, TAG_CARDHOLDER) as? Tlv.Primitive)?.let { extractCardholderName(it) }
+        val applicationLabel = (findFirst(nodes, TAG_LABEL) as? Tlv.Primitive)?.let { extractApplicationLabel(it) }
+        val track2Node = findFirst(nodes, TAG_TRACK2) as? Tlv.Primitive
+        val track2 = if (track2Node == null) {
+            null
+        } else {
+            when (val r = extractTrack2(track2Node)) {
+                is ExtractResult.Ok -> r.value
+                is ExtractResult.Err -> return OptionalOutcome.Err(r.error)
+            }
+        }
+        return OptionalOutcome.Ok(OptionalFields(cardholderName, applicationLabel, track2))
+    }
+
+    // ----- IAE message rendering -----
+
+    private fun messageFor(error: EmvCardError): String = when (error) {
+        EmvCardError.EmptyInput -> "EmvCard input is empty"
+        is EmvCardError.TlvDecodeFailed -> "EmvCard TLV decode failed: ${describeTlvError(error.cause)}"
+        is EmvCardError.MissingRequiredTag -> "EmvCard missing required tag ${error.tagHex}"
+        is EmvCardError.PanRejected -> "EmvCard PAN rejected: ${describePanError(error.cause)}"
+        is EmvCardError.Track2Rejected -> "EmvCard Track 2 rejected: ${describeTrack2Error(error.cause)}"
+        is EmvCardError.InvalidExpiryFormat -> "EmvCard expiry malformed: ${error.nibbleCount} nibbles"
+        is EmvCardError.InvalidExpiryMonth -> "EmvCard expiry month out of range: ${error.month}"
+        is EmvCardError.InvalidAid -> "EmvCard AID byte length out of range: ${error.byteCount}"
+        is EmvCardError.MalformedPanNibble -> "EmvCard PAN malformed BCD nibble at offset ${error.offset}"
+    }
+
+    private fun describePanError(cause: PanError): String = when (cause) {
+        is PanError.LengthOutOfRange -> "LengthOutOfRange"
+        PanError.NonDigitCharacters -> "NonDigitCharacters"
+        PanError.LuhnCheckFailed -> "LuhnCheckFailed"
+    }
+
+    private fun describeTrack2Error(cause: Track2Error): String = when (cause) {
+        Track2Error.EmptyInput -> "EmptyInput"
+        Track2Error.MissingSeparator -> "MissingSeparator"
+        is Track2Error.PanRejected -> "PanRejected:${describePanError(cause.cause)}"
+        is Track2Error.ExpiryTooShort -> "ExpiryTooShort"
+        is Track2Error.InvalidExpiryMonth -> "InvalidExpiryMonth"
+        Track2Error.ServiceCodeTooShort -> "ServiceCodeTooShort"
+        is Track2Error.MalformedBcdNibble -> "MalformedBcdNibble"
+        Track2Error.MalformedFPadding -> "MalformedFPadding"
+    }
+
+    private fun describeTlvError(cause: TlvError): String = when (cause) {
+        is TlvError.UnexpectedEof -> "UnexpectedEof"
+        is TlvError.IndefiniteLengthForbidden -> "IndefiniteLengthForbidden"
+        is TlvError.InvalidLengthOctet -> "InvalidLengthOctet"
+        is TlvError.IncompleteTag -> "IncompleteTag"
+        is TlvError.TagTooLong -> "TagTooLong"
+        is TlvError.NonMinimalTagEncoding -> "NonMinimalTagEncoding"
+        is TlvError.NonMinimalLengthEncoding -> "NonMinimalLengthEncoding"
+        is TlvError.ChildrenLengthMismatch -> "ChildrenLengthMismatch"
+        is TlvError.MaxDepthExceeded -> "MaxDepthExceeded"
+        is TlvError.LengthOverflow -> "LengthOverflow"
+    }
+}

--- a/shared/src/commonMain/kotlin/io/github/a7asoft/nfcemv/extract/internal/EmvFieldExtractors.kt
+++ b/shared/src/commonMain/kotlin/io/github/a7asoft/nfcemv/extract/internal/EmvFieldExtractors.kt
@@ -1,0 +1,164 @@
+package io.github.a7asoft.nfcemv.extract.internal
+
+import io.github.a7asoft.nfcemv.brand.Aid
+import io.github.a7asoft.nfcemv.extract.EmvCardError
+import io.github.a7asoft.nfcemv.extract.Pan
+import io.github.a7asoft.nfcemv.extract.PanResult
+import io.github.a7asoft.nfcemv.extract.Track2
+import io.github.a7asoft.nfcemv.extract.Track2Result
+import io.github.a7asoft.nfcemv.tlv.Tlv
+import kotlinx.datetime.YearMonth
+
+/**
+ * Result envelope for per-field extractors. Mirrors the toolkit's other
+ * sealed Ok/Err pairs (`PanResult`, `Track2Result`, `EmvCardResult`).
+ */
+internal sealed interface ExtractResult<out T> {
+    /** Successful extraction carrying the decoded value. */
+    data class Ok<T>(val value: T) : ExtractResult<T>
+
+    /** Extraction failed; see [error] for the typed reason. */
+    data class Err(val error: EmvCardError) : ExtractResult<Nothing>
+}
+
+/**
+ * Decode tag `4F` (Application Identifier) from a primitive node.
+ *
+ * Defers length validation to [Aid.fromBytes]; any length-out-of-range
+ * surfaces as [EmvCardError.InvalidAid].
+ */
+internal fun extractAid(node: Tlv.Primitive): ExtractResult<Aid> {
+    if (node.length !in MIN_AID_BYTES..MAX_AID_BYTES) {
+        return ExtractResult.Err(EmvCardError.InvalidAid(byteCount = node.length))
+    }
+    return ExtractResult.Ok(Aid.fromBytes(node.copyValue()))
+}
+
+/**
+ * Decode tag `5A` (Application PAN) from a primitive node.
+ *
+ * Tag `5A` uses CN format: BCD-packed digits with `0xF` padding when
+ * the digit count is odd. This extractor unpacks the nibbles, strips a
+ * single trailing `0xF` if present, and hands the resulting digit
+ * string to [Pan.parse]. Any rejection (length, digits, Luhn) surfaces
+ * as [EmvCardError.PanRejected].
+ */
+internal fun extractPan(node: Tlv.Primitive): ExtractResult<Pan> {
+    val bytes = node.copyValue()
+    return when (val unpacked = unpackPanDigits(bytes)) {
+        is UnpackResult.Err -> ExtractResult.Err(EmvCardError.MalformedPanNibble(offset = unpacked.offset))
+        is UnpackResult.Ok -> when (val parsed = Pan.parse(unpacked.digits)) {
+            is PanResult.Ok -> ExtractResult.Ok(parsed.pan)
+            is PanResult.Err -> ExtractResult.Err(EmvCardError.PanRejected(parsed.error))
+        }
+    }
+}
+
+private const val MIN_AID_BYTES: Int = 5
+private const val MAX_AID_BYTES: Int = 16
+private const val PAD_NIBBLE: Int = 0xF
+private const val EXPIRY_NIBBLE_COUNT: Int = 6
+private const val CENTURY_OFFSET: Int = 2000
+private const val MIN_MONTH: Int = 1
+private const val MAX_MONTH: Int = 12
+
+/**
+ * Decode tag `5F24` (Application Expiration Date) — `YYMMDD` BCD.
+ *
+ * Returns a [YearMonth] taking only the `YYMM` portion; the day field
+ * is read but discarded (per the issue spec, `EmvCard.expiry` is a
+ * month, not a date).
+ *
+ * **Two-digit-year mapping (deliberate deviation from EMV / no spec
+ * guidance):** EMV Book 3 §10.2 / Annex A defines tag `5F24` as `n 6`
+ * `YYMMDD` with no century encoding. Real kernels apply a sliding
+ * window relative to the terminal's current date. This toolkit
+ * intentionally chooses a static 21st-century mapping (`YY ⇒ 20YY`,
+ * range 2000..2099) because:
+ * 1. The toolkit targets EMV-issued cards, all of which post-date 2000.
+ * 2. Sliding-window mapping requires a clock; this is a pure-parser
+ *    layer with no time injection point in v0.1.x.
+ * 3. The mapping is consistent project-wide with `Track2.expiry` (#6).
+ *
+ * Cards expiring 2100+ silently mis-map to `20XX`. A future
+ * `EmvParserOptions(today: LocalDate)` parameter could enable the
+ * sliding window; that's tracked separately and out of scope for
+ * v0.1.x. The static mapping is pinned by a regression test.
+ */
+internal fun extractExpiry(node: Tlv.Primitive): ExtractResult<YearMonth> {
+    val bytes = node.copyValue()
+    val nibbleCount = bytes.nibbleCount()
+    if (nibbleCount != EXPIRY_NIBBLE_COUNT) {
+        return ExtractResult.Err(EmvCardError.InvalidExpiryFormat(nibbleCount = nibbleCount))
+    }
+    val yy = bytes.nibbleAt(0) * 10 + bytes.nibbleAt(1)
+    val mm = bytes.nibbleAt(2) * 10 + bytes.nibbleAt(3)
+    if (mm !in MIN_MONTH..MAX_MONTH) {
+        return ExtractResult.Err(EmvCardError.InvalidExpiryMonth(month = mm))
+    }
+    return ExtractResult.Ok(YearMonth(CENTURY_OFFSET + yy, mm))
+}
+
+/**
+ * Decode tag `5F20` (Cardholder Name) — `AN` ISO-8859-1 bytes,
+ * right-padded with `0x20`. Returns `null` when the value is empty
+ * or contains only spaces.
+ *
+ * The returned `String` carries cardholder personally-identifying
+ * information per PCI DSS Cardholder Data scope. Caller MUST NOT log
+ * it raw; downstream code should route it through a typed extractor
+ * or mask before any persistence / transmission. `EmvCard.toString`
+ * enforces this by emitting a length-only placeholder.
+ */
+internal fun extractCardholderName(node: Tlv.Primitive): String? =
+    decodeTrimmedLatin1(node.copyValue())
+
+/**
+ * Decode tag `50` (Application Label) — `AN` ISO-8859-1 bytes,
+ * right-padded with `0x20`. Returns `null` when the value is empty
+ * or contains only spaces.
+ *
+ * Application Label is operational metadata, not PCI data — safe to
+ * log raw.
+ */
+internal fun extractApplicationLabel(node: Tlv.Primitive): String? =
+    decodeTrimmedLatin1(node.copyValue())
+
+private fun decodeTrimmedLatin1(bytes: ByteArray): String? {
+    if (bytes.isEmpty()) return null
+    val text = buildString(bytes.size) {
+        for (b in bytes) append(Char(b.toInt() and 0xFF))
+    }.trimEnd(' ')
+    return text.ifEmpty { null }
+}
+
+/**
+ * Decode tag `57` (Track 2 Equivalent Data) by delegating to
+ * [Track2.parse]. Failures wrap as [EmvCardError.Track2Rejected].
+ */
+internal fun extractTrack2(node: Tlv.Primitive): ExtractResult<Track2> =
+    when (val parsed = Track2.parse(node.copyValue())) {
+        is Track2Result.Ok -> ExtractResult.Ok(parsed.track2)
+        is Track2Result.Err -> ExtractResult.Err(EmvCardError.Track2Rejected(parsed.error))
+    }
+
+private sealed interface UnpackResult {
+    data class Ok(val digits: String) : UnpackResult
+    data class Err(val offset: Int) : UnpackResult
+}
+
+private fun unpackPanDigits(bytes: ByteArray): UnpackResult {
+    val totalNibbles = bytes.nibbleCount()
+    if (totalNibbles == 0) return UnpackResult.Ok("")
+    val effective =
+        if (bytes.nibbleAt(totalNibbles - 1) == PAD_NIBBLE) totalNibbles - 1 else totalNibbles
+    for (i in 0 until effective) {
+        val n = bytes.nibbleAt(i)
+        if (n !in 0..9) return UnpackResult.Err(offset = i)
+    }
+    return UnpackResult.Ok(
+        buildString(effective) {
+            for (i in 0 until effective) append('0' + bytes.nibbleAt(i))
+        },
+    )
+}

--- a/shared/src/commonMain/kotlin/io/github/a7asoft/nfcemv/extract/internal/TlvSearch.kt
+++ b/shared/src/commonMain/kotlin/io/github/a7asoft/nfcemv/extract/internal/TlvSearch.kt
@@ -1,0 +1,25 @@
+package io.github.a7asoft.nfcemv.extract.internal
+
+import io.github.a7asoft.nfcemv.tlv.Tag
+import io.github.a7asoft.nfcemv.tlv.Tlv
+
+/**
+ * Depth-first search across a forest of [Tlv] roots and their constructed
+ * children, returning the first node whose tag equals [target].
+ *
+ * Used by `EmvParser` to locate required and optional tags inside the
+ * concatenated TLV trees decoded from APDU responses.
+ *
+ * Recursion is bounded by the decoder's `TlvOptions.maxDepth`; this
+ * search adds no further bound because the input was already validated.
+ */
+internal fun findFirst(tlvs: List<Tlv>, target: Tag): Tlv? {
+    for (node in tlvs) {
+        if (node.tag == target) return node
+        if (node is Tlv.Constructed) {
+            val child = findFirst(node.children, target)
+            if (child != null) return child
+        }
+    }
+    return null
+}

--- a/shared/src/commonTest/kotlin/io/github/a7asoft/nfcemv/extract/EmvCardTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/a7asoft/nfcemv/extract/EmvCardTest.kt
@@ -1,0 +1,89 @@
+package io.github.a7asoft.nfcemv.extract
+
+import io.github.a7asoft.nfcemv.brand.Aid
+import io.github.a7asoft.nfcemv.brand.EmvBrand
+import kotlinx.datetime.YearMonth
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+
+class EmvCardTest {
+
+    private fun sample(
+        cardholderName: String? = "VISA TEST",
+        applicationLabel: String? = "VISA",
+        track2: Track2? = null,
+    ): EmvCard = EmvCard(
+        pan = Pan.parseOrThrow("4111111111111111"),
+        expiry = YearMonth(2028, 12),
+        cardholderName = cardholderName,
+        brand = EmvBrand.VISA,
+        applicationLabel = applicationLabel,
+        track2 = track2,
+        aid = Aid.fromHex("A0000000031010"),
+    )
+
+    @Test
+    fun `toString masks the PAN via Pan toString`() {
+        assertFalse("4111111111111111" in sample().toString())
+    }
+
+    @Test
+    fun `toString reports cardholderName as a length-only placeholder`() {
+        assertEquals(true, "<9 chars>" in sample().toString())
+    }
+
+    @Test
+    fun `toString never embeds the raw cardholder name string`() {
+        assertFalse("VISA TEST" in sample().toString())
+    }
+
+    @Test
+    fun `toString reports cardholderName as null literal when null`() {
+        assertEquals(true, "cardholderName=null" in sample(cardholderName = null).toString())
+    }
+
+    @Test
+    fun `toString shows the application label raw because it is not PCI`() {
+        assertEquals(true, "applicationLabel=VISA" in sample().toString())
+    }
+
+    @Test
+    fun `equality is data-class structural over all fields`() {
+        assertEquals(sample(), sample())
+    }
+
+    @Test
+    fun `equality differs when cardholderName differs`() {
+        assertNotEquals(sample(cardholderName = "A"), sample(cardholderName = "B"))
+    }
+
+    @Test
+    fun `componentN destructuring exposes the public fields`() {
+        val card = sample()
+        val (pan, expiry, cardholderName, brand, applicationLabel, track2, aid) = card
+        assertEquals(card.pan, pan)
+        assertEquals(card.expiry, expiry)
+        assertEquals(card.cardholderName, cardholderName)
+        assertEquals(card.brand, brand)
+        assertEquals(card.applicationLabel, applicationLabel)
+        assertEquals(card.track2, track2)
+        assertEquals(card.aid, aid)
+    }
+
+    @Test
+    fun `toString delegates to Track2 toString when track2 is non-null`() {
+        val track2 = io.github.a7asoft.nfcemv.extract.Track2.parseOrThrow(byteArrayOf(
+            0x41, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11,
+            0xD2.toByte(), 0x81.toByte(), 0x22, 0x01, 0x00, 0x00,
+        ))
+        val card = sample(track2 = track2)
+        val rendered = card.toString()
+        // Track2.toString masks PAN and discretionary; pin that the
+        // EmvCard's toString includes the Track2 representation but no
+        // raw PAN.
+        kotlin.test.assertFalse("4111111111111111" in rendered)
+        kotlin.test.assertTrue("track2=Track2" in rendered)
+    }
+}

--- a/shared/src/commonTest/kotlin/io/github/a7asoft/nfcemv/extract/EmvParserTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/a7asoft/nfcemv/extract/EmvParserTest.kt
@@ -1,0 +1,384 @@
+package io.github.a7asoft.nfcemv.extract
+
+import io.github.a7asoft.nfcemv.brand.Aid
+import io.github.a7asoft.nfcemv.brand.EmvBrand
+import kotlinx.datetime.YearMonth
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class EmvParserTest {
+
+    /**
+     * Canonical 60-byte EMV record fixture wrapping all six tags in a
+     * `70` template. Mirrors the structure documented in the plan.
+     */
+    private val canonicalRecord: ByteArray = byteArrayOf(
+        0x70, 0x3B,
+        // 4F AID = A0000000031010
+        0x4F, 0x07, 0xA0.toByte(), 0x00, 0x00, 0x00, 0x03, 0x10, 0x10,
+        // 5A PAN = 4111111111111111
+        0x5A, 0x08, 0x41, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11,
+        // 5F24 expiry = 28 12 31 (Dec 2028)
+        0x5F, 0x24, 0x03, 0x28, 0x12, 0x31,
+        // 5F20 cardholder = "VISA TEST"
+        0x5F, 0x20, 0x09, 0x56, 0x49, 0x53, 0x41, 0x20, 0x54, 0x45, 0x53, 0x54,
+        // 50 label = "VISA"
+        0x50, 0x04, 0x56, 0x49, 0x53, 0x41,
+        // 57 Track 2 (14 bytes BCD)
+        0x57, 0x0E,
+        0x41, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11,
+        0xD2.toByte(), 0x81.toByte(), 0x22, 0x01, 0x00, 0x00,
+    )
+
+    @Test
+    fun `parse extracts the PAN from the canonical fixture`() {
+        val ok = assertIs<EmvCardResult.Ok>(EmvParser.parse(listOf(canonicalRecord)))
+        assertEquals("4111111111111111", ok.card.pan.unmasked())
+    }
+
+    @Test
+    fun `parse extracts the expiry from the canonical fixture`() {
+        val ok = assertIs<EmvCardResult.Ok>(EmvParser.parse(listOf(canonicalRecord)))
+        assertEquals(YearMonth(2028, 12), ok.card.expiry)
+    }
+
+    @Test
+    fun `parse extracts the AID from the canonical fixture`() {
+        val ok = assertIs<EmvCardResult.Ok>(EmvParser.parse(listOf(canonicalRecord)))
+        assertEquals(Aid.fromHex("A0000000031010"), ok.card.aid)
+    }
+
+    @Test
+    fun `parse resolves the brand to VISA from the canonical fixture`() {
+        val ok = assertIs<EmvCardResult.Ok>(EmvParser.parse(listOf(canonicalRecord)))
+        assertEquals(EmvBrand.VISA, ok.card.brand)
+    }
+
+    @Test
+    fun `parse extracts the cardholder name from the canonical fixture`() {
+        val ok = assertIs<EmvCardResult.Ok>(EmvParser.parse(listOf(canonicalRecord)))
+        assertEquals("VISA TEST", ok.card.cardholderName)
+    }
+
+    @Test
+    fun `parse extracts the application label from the canonical fixture`() {
+        val ok = assertIs<EmvCardResult.Ok>(EmvParser.parse(listOf(canonicalRecord)))
+        assertEquals("VISA", ok.card.applicationLabel)
+    }
+
+    @Test
+    fun `parse extracts the Track 2 PAN when tag 57 is present`() {
+        val ok = assertIs<EmvCardResult.Ok>(EmvParser.parse(listOf(canonicalRecord)))
+        val track2 = assertNotNull(ok.card.track2)
+        assertEquals("4111111111111111", track2.pan.unmasked())
+    }
+
+    @Test
+    fun `parse extracts the Track 2 expiry when tag 57 is present`() {
+        val ok = assertIs<EmvCardResult.Ok>(EmvParser.parse(listOf(canonicalRecord)))
+        val track2 = assertNotNull(ok.card.track2)
+        assertEquals(YearMonth(2028, 12), track2.expiry)
+    }
+
+    @Test
+    fun `parse extracts the Track 2 service code when tag 57 is present`() {
+        val ok = assertIs<EmvCardResult.Ok>(EmvParser.parse(listOf(canonicalRecord)))
+        val track2 = assertNotNull(ok.card.track2)
+        assertEquals("201", track2.serviceCode.toString())
+    }
+
+    @Test
+    fun `parse returns track2 null when tag 57 is absent`() {
+        val without57 = byteArrayOf(
+            0x70, 0x2B,
+            0x4F, 0x07, 0xA0.toByte(), 0x00, 0x00, 0x00, 0x03, 0x10, 0x10,
+            0x5A, 0x08, 0x41, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11,
+            0x5F, 0x24, 0x03, 0x28, 0x12, 0x31,
+            0x5F, 0x20, 0x09, 0x56, 0x49, 0x53, 0x41, 0x20, 0x54, 0x45, 0x53, 0x54,
+            0x50, 0x04, 0x56, 0x49, 0x53, 0x41,
+        )
+        val ok = assertIs<EmvCardResult.Ok>(EmvParser.parse(listOf(without57)))
+        assertNull(ok.card.track2)
+    }
+
+    @Test
+    fun `parse rejects empty input with EmptyInput`() {
+        val err = assertIs<EmvCardResult.Err>(EmvParser.parse(emptyList()))
+        assertEquals(EmvCardError.EmptyInput, err.error)
+    }
+
+    @Test
+    fun `parse surfaces TlvDecodeFailed with InvalidLengthOctet on a 0xFF length byte`() {
+        // 0xFF is reserved per ISO 8825-1 §8.1.3.5c.
+        val malformed = byteArrayOf(0x4F, 0xFF.toByte(), 0x00)
+        val err = assertIs<EmvCardResult.Err>(EmvParser.parse(listOf(malformed)))
+        val tlvErr = assertIs<EmvCardError.TlvDecodeFailed>(err.error)
+        assertIs<io.github.a7asoft.nfcemv.tlv.TlvError.InvalidLengthOctet>(tlvErr.cause)
+    }
+
+    @Test
+    fun `parse surfaces MissingRequiredTag 4F when AID is absent`() {
+        val raw = byteArrayOf(
+            0x70, 0x10,
+            0x5A, 0x08, 0x41, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11,
+            0x5F, 0x24, 0x03, 0x28, 0x12, 0x31,
+        )
+        val err = assertIs<EmvCardResult.Err>(EmvParser.parse(listOf(raw)))
+        assertEquals(EmvCardError.MissingRequiredTag(tagHex = "4F"), err.error)
+    }
+
+    @Test
+    fun `parse surfaces MissingRequiredTag 5A when PAN is absent`() {
+        val raw = byteArrayOf(
+            0x70, 0x0F,
+            0x4F, 0x07, 0xA0.toByte(), 0x00, 0x00, 0x00, 0x03, 0x10, 0x10,
+            0x5F, 0x24, 0x03, 0x28, 0x12, 0x31,
+        )
+        val err = assertIs<EmvCardResult.Err>(EmvParser.parse(listOf(raw)))
+        assertEquals(EmvCardError.MissingRequiredTag(tagHex = "5A"), err.error)
+    }
+
+    @Test
+    fun `parse surfaces MissingRequiredTag 5F24 when expiry is absent`() {
+        val raw = byteArrayOf(
+            0x70, 0x13,
+            0x4F, 0x07, 0xA0.toByte(), 0x00, 0x00, 0x00, 0x03, 0x10, 0x10,
+            0x5A, 0x08, 0x41, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11,
+        )
+        val err = assertIs<EmvCardResult.Err>(EmvParser.parse(listOf(raw)))
+        assertEquals(EmvCardError.MissingRequiredTag(tagHex = "5F24"), err.error)
+    }
+
+    @Test
+    fun `parse surfaces PanRejected when PAN fails Luhn`() {
+        val raw = byteArrayOf(
+            0x70, 0x19,
+            0x4F, 0x07, 0xA0.toByte(), 0x00, 0x00, 0x00, 0x03, 0x10, 0x10,
+            0x5A, 0x08, 0x41, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x12,
+            0x5F, 0x24, 0x03, 0x28, 0x12, 0x31,
+        )
+        val err = assertIs<EmvCardResult.Err>(EmvParser.parse(listOf(raw)))
+        val panErr = assertIs<EmvCardError.PanRejected>(err.error)
+        assertEquals(PanError.LuhnCheckFailed, panErr.cause)
+    }
+
+    @Test
+    fun `parse surfaces InvalidExpiryMonth when month is 13`() {
+        val raw = byteArrayOf(
+            0x70, 0x19,
+            0x4F, 0x07, 0xA0.toByte(), 0x00, 0x00, 0x00, 0x03, 0x10, 0x10,
+            0x5A, 0x08, 0x41, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11,
+            0x5F, 0x24, 0x03, 0x28, 0x13, 0x31,
+        )
+        val err = assertIs<EmvCardResult.Err>(EmvParser.parse(listOf(raw)))
+        assertEquals(EmvCardError.InvalidExpiryMonth(month = 13), err.error)
+    }
+
+    @Test
+    fun `parseOrThrow returns the EmvCard for the canonical fixture`() {
+        val card = EmvParser.parseOrThrow(listOf(canonicalRecord))
+        assertEquals("4111111111111111", card.pan.unmasked())
+    }
+
+    @Test
+    fun `parseOrThrow throws IllegalArgumentException on EmptyInput with PCI-safe message`() {
+        val ex = kotlin.test.assertFailsWith<IllegalArgumentException> {
+            EmvParser.parseOrThrow(emptyList())
+        }
+        assertEquals("EmvCard input is empty", ex.message)
+    }
+
+    @Test
+    fun `parseOrThrow IAE on Luhn fail does not embed the raw PAN`() {
+        val raw = byteArrayOf(
+            0x70, 0x19,
+            0x4F, 0x07, 0xA0.toByte(), 0x00, 0x00, 0x00, 0x03, 0x10, 0x10,
+            0x5A, 0x08, 0x41, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x12,
+            0x5F, 0x24, 0x03, 0x28, 0x12, 0x31,
+        )
+        val ex = kotlin.test.assertFailsWith<IllegalArgumentException> {
+            EmvParser.parseOrThrow(listOf(raw))
+        }
+        val msg = ex.message ?: ""
+        kotlin.test.assertFalse("4111111111111112" in msg)
+        kotlin.test.assertFalse("411111" in msg)
+        kotlin.test.assertFalse("1112" in msg)
+        assertEquals("EmvCard PAN rejected: LuhnCheckFailed", msg)
+    }
+
+    @Test
+    fun `EmvCard toString from a parsed canonical fixture never embeds the raw PAN`() {
+        val card = EmvParser.parseOrThrow(listOf(canonicalRecord))
+        kotlin.test.assertFalse("4111111111111111" in card.toString())
+    }
+
+    @Test
+    fun `EmvCard toString from a parsed canonical fixture never embeds the raw cardholder name`() {
+        val card = EmvParser.parseOrThrow(listOf(canonicalRecord))
+        kotlin.test.assertFalse("VISA TEST" in card.toString())
+    }
+
+    @Test
+    fun `EmvCard toString from a parsed canonical fixture reports cardholder name as 9 chars placeholder`() {
+        val card = EmvParser.parseOrThrow(listOf(canonicalRecord))
+        kotlin.test.assertTrue("<9 chars>" in card.toString())
+    }
+
+    @Test
+    fun `parser never crashes on arbitrary List of ByteArray input`() {
+        // 1,000 deterministic random buffers of varying sizes and counts.
+        // Contract: parse returns either Ok or Err — no other exception
+        // (IndexOutOfBounds, NumberFormatException, IllegalStateException
+        // from internal invariants) escapes. Mirrors TlvDecoderFuzzTest
+        // and Track2 fuzz patterns.
+        val rng = kotlin.random.Random(FUZZ_SEED)
+        var okCount = 0
+        var errCount = 0
+        repeat(FUZZ_ITERATIONS) {
+            val responseCount = rng.nextInt(0, FUZZ_MAX_RESPONSES + 1)
+            val responses = List(responseCount) {
+                val len = rng.nextInt(0, FUZZ_MAX_INPUT_BYTES + 1)
+                ByteArray(len).also { rng.nextBytes(it) }
+            }
+            when (EmvParser.parse(responses)) {
+                is EmvCardResult.Ok -> okCount++
+                is EmvCardResult.Err -> errCount++
+            }
+        }
+        kotlin.test.assertTrue(okCount + errCount == FUZZ_ITERATIONS)
+        // Sanity: random bytes almost never produce a valid EmvCard but
+        // they MUST resolve to typed Err. Pin that errCount > 0 to confirm
+        // the test exercises the Err branch.
+        kotlin.test.assertTrue(errCount > 0, "expected some rejections, got 0")
+    }
+
+    @Test
+    fun `parse handles a List of multiple APDU response ByteArrays`() {
+        // Split the canonical fixture into TWO ByteArrays: one carrying
+        // the 4F + 5A + 5F24 + 5F20 + 50 wrapper, the other carrying the
+        // 57 Track 2 entry. Both must merge into a single EmvCard.
+        //
+        // First template inner: 4F (9) + 5A (10) + 5F24 (6) +
+        //   5F20 (12: 2-byte tag + 1 length + 9 value) + 50 (6) = 43 bytes.
+        //   Outer: 70 2B.
+        // Second template (16 bytes inner): 57 (16). Outer: 70 10.
+        val first = byteArrayOf(
+            0x70, 0x2B,
+            0x4F, 0x07, 0xA0.toByte(), 0x00, 0x00, 0x00, 0x03, 0x10, 0x10,
+            0x5A, 0x08, 0x41, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11,
+            0x5F, 0x24, 0x03, 0x28, 0x12, 0x31,
+            0x5F, 0x20, 0x09, 0x56, 0x49, 0x53, 0x41, 0x20, 0x54, 0x45, 0x53, 0x54,
+            0x50, 0x04, 0x56, 0x49, 0x53, 0x41,
+        )
+        val second = byteArrayOf(
+            0x70, 0x10,
+            0x57, 0x0E,
+            0x41, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11,
+            0xD2.toByte(), 0x81.toByte(), 0x22, 0x01, 0x00, 0x00,
+        )
+        val ok = assertIs<EmvCardResult.Ok>(EmvParser.parse(listOf(first, second)))
+        val card = ok.card
+        assertEquals("4111111111111111", card.pan.unmasked())
+        assertEquals(YearMonth(2028, 12), card.expiry)
+        assertEquals("VISA TEST", card.cardholderName)
+        assertEquals("VISA", card.applicationLabel)
+        assertNotNull(card.track2)
+    }
+
+    @Test
+    fun `parse decodes a Latin-1 cardholder name across high bytes`() {
+        // Replace the canonical fixture's 5F20 entry with "MÜLLER" (Latin-1)
+        // M=0x4D, Ü=0xDC, L=0x4C, L=0x4C, E=0x45, R=0x52.
+        // 5F 20 06 4D DC 4C 4C 45 52 — 9 bytes total
+        // Outer template inner = 4F (9) + 5A (10) + 5F24 (6) + 5F20 (9) +
+        //   50 (6) + 57 (16) = 56 bytes. Outer 70 38.
+        val raw = byteArrayOf(
+            0x70, 0x38,
+            0x4F, 0x07, 0xA0.toByte(), 0x00, 0x00, 0x00, 0x03, 0x10, 0x10,
+            0x5A, 0x08, 0x41, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11,
+            0x5F, 0x24, 0x03, 0x28, 0x12, 0x31,
+            0x5F, 0x20, 0x06, 0x4D, 0xDC.toByte(), 0x4C, 0x4C, 0x45, 0x52,
+            0x50, 0x04, 0x56, 0x49, 0x53, 0x41,
+            0x57, 0x0E,
+            0x41, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11,
+            0xD2.toByte(), 0x81.toByte(), 0x22, 0x01, 0x00, 0x00,
+        )
+        val ok = assertIs<EmvCardResult.Ok>(EmvParser.parse(listOf(raw)))
+        assertEquals("MÜLLER", ok.card.cardholderName)
+    }
+
+    @Test
+    fun `parse surfaces InvalidAid when the 4F entry has too few bytes`() {
+        // 4F entry with 4-byte value (below the 5-byte AID minimum).
+        // 5A and 5F24 present and valid.
+        // 4F entry: 4F 04 A0 00 00 00 = 6 bytes
+        // Inner: 6 + 10 + 6 = 22 bytes. Outer 70 16.
+        val raw = byteArrayOf(
+            0x70, 0x16,
+            0x4F, 0x04, 0xA0.toByte(), 0x00, 0x00, 0x00,
+            0x5A, 0x08, 0x41, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11,
+            0x5F, 0x24, 0x03, 0x28, 0x12, 0x31,
+        )
+        val err = assertIs<EmvCardResult.Err>(EmvParser.parse(listOf(raw)))
+        assertEquals(EmvCardError.InvalidAid(byteCount = 4), err.error)
+    }
+
+    @Test
+    fun `parse surfaces Track2Rejected when tag 57 is present but malformed`() {
+        // Tag 57 with no D separator — Track2.parse rejects with
+        // MissingSeparator, surfaces as EmvCardError.Track2Rejected.
+        // 57 entry: 57 08 41 11 11 11 11 11 11 11 = 10 bytes (no D in PAN).
+        // Inner: 9 + 10 + 6 + 10 = 35 bytes. Outer 70 23.
+        val raw = byteArrayOf(
+            0x70, 0x23,
+            0x4F, 0x07, 0xA0.toByte(), 0x00, 0x00, 0x00, 0x03, 0x10, 0x10,
+            0x5A, 0x08, 0x41, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11,
+            0x5F, 0x24, 0x03, 0x28, 0x12, 0x31,
+            0x57, 0x08, 0x41, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11,
+        )
+        val err = assertIs<EmvCardResult.Err>(EmvParser.parse(listOf(raw)))
+        val t2err = assertIs<EmvCardError.Track2Rejected>(err.error)
+        assertEquals(io.github.a7asoft.nfcemv.extract.Track2Error.MissingSeparator, t2err.cause)
+    }
+
+    @Test
+    fun `parse surfaces InvalidExpiryFormat when 5F24 is 2 bytes`() {
+        // 5F24 entry: 5F 24 02 28 12 = 5 bytes (2-byte value, expected 3).
+        // Inner: 9 + 10 + 5 = 24 bytes. Outer 70 18.
+        val raw = byteArrayOf(
+            0x70, 0x18,
+            0x4F, 0x07, 0xA0.toByte(), 0x00, 0x00, 0x00, 0x03, 0x10, 0x10,
+            0x5A, 0x08, 0x41, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11,
+            0x5F, 0x24, 0x02, 0x28, 0x12,
+        )
+        val err = assertIs<EmvCardResult.Err>(EmvParser.parse(listOf(raw)))
+        assertEquals(EmvCardError.InvalidExpiryFormat(nibbleCount = 4), err.error)
+    }
+
+    @Test
+    fun `parse surfaces MalformedPanNibble when 5A contains a non-digit nibble`() {
+        // 5A entry with 0xA at nibble position 3 (second byte's high
+        // nibble). Mirror the unit-level test from Task 2.
+        // 5A entry: 5A 08 41 1A 11 11 11 11 11 11 = 10 bytes.
+        // Inner: 9 + 10 + 6 = 25 bytes. Outer 70 19.
+        val raw = byteArrayOf(
+            0x70, 0x19,
+            0x4F, 0x07, 0xA0.toByte(), 0x00, 0x00, 0x00, 0x03, 0x10, 0x10,
+            0x5A, 0x08, 0x41, 0x1A, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11,
+            0x5F, 0x24, 0x03, 0x28, 0x12, 0x31,
+        )
+        val err = assertIs<EmvCardResult.Err>(EmvParser.parse(listOf(raw)))
+        val malformed = assertIs<EmvCardError.MalformedPanNibble>(err.error)
+        assertEquals(3, malformed.offset)
+    }
+
+    private companion object {
+        const val FUZZ_SEED: Long = 0x454D5643L // "EMVC"
+        const val FUZZ_ITERATIONS: Int = 1_000
+        const val FUZZ_MAX_RESPONSES: Int = 4
+        const val FUZZ_MAX_INPUT_BYTES: Int = 64
+    }
+}

--- a/shared/src/commonTest/kotlin/io/github/a7asoft/nfcemv/extract/internal/EmvFieldExtractorsTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/a7asoft/nfcemv/extract/internal/EmvFieldExtractorsTest.kt
@@ -1,0 +1,294 @@
+package io.github.a7asoft.nfcemv.extract.internal
+
+import io.github.a7asoft.nfcemv.brand.Aid
+import io.github.a7asoft.nfcemv.extract.EmvCardError
+import io.github.a7asoft.nfcemv.extract.Pan
+import io.github.a7asoft.nfcemv.extract.PanError
+import io.github.a7asoft.nfcemv.extract.Track2
+import io.github.a7asoft.nfcemv.extract.Track2Error
+import io.github.a7asoft.nfcemv.tlv.Tag
+import io.github.a7asoft.nfcemv.tlv.Tlv
+import kotlinx.datetime.YearMonth
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class EmvFieldExtractorsTest {
+
+    // ---- AID ----
+
+    @Test
+    fun `extractAid returns the Aid for a valid 7-byte 4F primitive`() {
+        val node = Tlv.Primitive(
+            Tag.fromHex("4F"),
+            byteArrayOf(0xA0.toByte(), 0x00, 0x00, 0x00, 0x03, 0x10, 0x10),
+        )
+        val result = extractAid(node)
+        assertIs<ExtractResult.Ok<Aid>>(result)
+        assertEquals("A0000000031010", result.value.toString())
+    }
+
+    @Test
+    fun `extractAid surfaces InvalidAid when the byte count is below 5`() {
+        val node = Tlv.Primitive(
+            Tag.fromHex("4F"),
+            byteArrayOf(0xA0.toByte(), 0x00, 0x00),
+        )
+        val result = extractAid(node)
+        val err = assertIs<ExtractResult.Err>(result)
+        assertEquals(EmvCardError.InvalidAid(byteCount = 3), err.error)
+    }
+
+    @Test
+    fun `extractAid surfaces InvalidAid when the byte count is above 16`() {
+        val node = Tlv.Primitive(
+            Tag.fromHex("4F"),
+            ByteArray(17),
+        )
+        val result = extractAid(node)
+        val err = assertIs<ExtractResult.Err>(result)
+        assertEquals(EmvCardError.InvalidAid(byteCount = 17), err.error)
+    }
+
+    // ---- PAN ----
+
+    @Test
+    fun `extractPan returns a Pan for a 16-digit BCD-packed 5A primitive`() {
+        val node = Tlv.Primitive(
+            Tag.fromHex("5A"),
+            byteArrayOf(0x41, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11),
+        )
+        val result = extractPan(node)
+        val ok = assertIs<ExtractResult.Ok<Pan>>(result)
+        assertEquals("4111111111111111", ok.value.unmasked())
+    }
+
+    @Test
+    fun `extractPan strips a single trailing F-pad nibble`() {
+        val node = Tlv.Primitive(
+            Tag.fromHex("5A"),
+            byteArrayOf(0x42, 0x22, 0x22, 0x22, 0x22, 0x22, 0x2F),
+        )
+        val result = extractPan(node)
+        val ok = assertIs<ExtractResult.Ok<Pan>>(result)
+        assertEquals("4222222222222", ok.value.unmasked())
+    }
+
+    @Test
+    fun `extractPan surfaces PanRejected when Pan parse fails Luhn`() {
+        val node = Tlv.Primitive(
+            Tag.fromHex("5A"),
+            byteArrayOf(0x41, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x12),
+        )
+        val result = extractPan(node)
+        val err = assertIs<ExtractResult.Err>(result)
+        val panErr = assertIs<EmvCardError.PanRejected>(err.error)
+        assertEquals(PanError.LuhnCheckFailed, panErr.cause)
+    }
+
+    @Test
+    fun `extractPan surfaces MalformedPanNibble at the actual offending offset`() {
+        // Inject 0xA at nibble position 3 (third nibble of the second byte).
+        val node = Tlv.Primitive(
+            Tag.fromHex("5A"),
+            byteArrayOf(0x41, 0x1A, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11),
+        )
+        val result = extractPan(node)
+        val err = assertIs<ExtractResult.Err>(result)
+        val malformed = assertIs<EmvCardError.MalformedPanNibble>(err.error)
+        assertEquals(3, malformed.offset)
+    }
+
+    @Test
+    fun `extractPan surfaces MalformedPanNibble for non-trailing F at offset 4`() {
+        // 0xF at nibble position 4 (mid-string), final nibble is 1 (not F).
+        // Stripping logic only strips a trailing 0xF, so this F at offset 4
+        // is correctly flagged as malformed.
+        val node = Tlv.Primitive(
+            Tag.fromHex("5A"),
+            byteArrayOf(0x41, 0x11, 0xF1.toByte(), 0x11, 0x11, 0x11, 0x11, 0x11),
+        )
+        val result = extractPan(node)
+        val err = assertIs<ExtractResult.Err>(result)
+        val malformed = assertIs<EmvCardError.MalformedPanNibble>(err.error)
+        assertEquals(4, malformed.offset)
+    }
+
+    // ---- Expiry ----
+
+    @Test
+    fun `extractExpiry returns YearMonth 2028-12 for 281231`() {
+        val node = Tlv.Primitive(
+            Tag.fromHex("5F24"),
+            byteArrayOf(0x28, 0x12, 0x31),
+        )
+        val result = extractExpiry(node)
+        val ok = assertIs<ExtractResult.Ok<YearMonth>>(result)
+        assertEquals(YearMonth(2028, 12), ok.value)
+    }
+
+    @Test
+    fun `extractExpiry surfaces InvalidExpiryFormat for a 2-byte value`() {
+        val node = Tlv.Primitive(
+            Tag.fromHex("5F24"),
+            byteArrayOf(0x28, 0x12),
+        )
+        val result = extractExpiry(node)
+        val err = assertIs<ExtractResult.Err>(result)
+        assertEquals(EmvCardError.InvalidExpiryFormat(nibbleCount = 4), err.error)
+    }
+
+    @Test
+    fun `extractExpiry surfaces InvalidExpiryFormat for a 4-byte value`() {
+        val node = Tlv.Primitive(
+            Tag.fromHex("5F24"),
+            byteArrayOf(0x28, 0x12, 0x31, 0x00),
+        )
+        val result = extractExpiry(node)
+        val err = assertIs<ExtractResult.Err>(result)
+        assertEquals(EmvCardError.InvalidExpiryFormat(nibbleCount = 8), err.error)
+    }
+
+    @Test
+    fun `extractExpiry surfaces InvalidExpiryMonth for month 00`() {
+        val node = Tlv.Primitive(
+            Tag.fromHex("5F24"),
+            byteArrayOf(0x28, 0x00, 0x31),
+        )
+        val result = extractExpiry(node)
+        val err = assertIs<ExtractResult.Err>(result)
+        assertEquals(EmvCardError.InvalidExpiryMonth(month = 0), err.error)
+    }
+
+    @Test
+    fun `extractExpiry surfaces InvalidExpiryMonth for month 13`() {
+        val node = Tlv.Primitive(
+            Tag.fromHex("5F24"),
+            byteArrayOf(0x28, 0x13, 0x31),
+        )
+        val result = extractExpiry(node)
+        val err = assertIs<ExtractResult.Err>(result)
+        assertEquals(EmvCardError.InvalidExpiryMonth(month = 13), err.error)
+    }
+
+    @Test
+    fun `extractExpiry maps YY equal to 00 to year 2000 per the documented v0_1_x deviation`() {
+        val node = Tlv.Primitive(
+            Tag.fromHex("5F24"),
+            byteArrayOf(0x00, 0x01, 0x01),
+        )
+        val result = extractExpiry(node)
+        val ok = assertIs<ExtractResult.Ok<YearMonth>>(result)
+        assertEquals(YearMonth(2000, 1), ok.value)
+    }
+
+    @Test
+    fun `extractExpiry maps YY equal to 99 to year 2099 per the documented v0_1_x deviation`() {
+        val node = Tlv.Primitive(
+            Tag.fromHex("5F24"),
+            byteArrayOf(0x99.toByte(), 0x12, 0x31),
+        )
+        val result = extractExpiry(node)
+        val ok = assertIs<ExtractResult.Ok<YearMonth>>(result)
+        assertEquals(YearMonth(2099, 12), ok.value)
+    }
+
+    // ---- Cardholder name + Application label ----
+
+    @Test
+    fun `extractCardholderName returns the trimmed ASCII string`() {
+        val node = Tlv.Primitive(
+            Tag.fromHex("5F20"),
+            "VISA TEST".encodeToByteArray(),
+        )
+        assertEquals("VISA TEST", extractCardholderName(node))
+    }
+
+    @Test
+    fun `extractCardholderName strips trailing 0x20 spaces`() {
+        val node = Tlv.Primitive(
+            Tag.fromHex("5F20"),
+            "VISA TEST     ".encodeToByteArray(),
+        )
+        assertEquals("VISA TEST", extractCardholderName(node))
+    }
+
+    @Test
+    fun `extractCardholderName returns null on an all-spaces value`() {
+        val node = Tlv.Primitive(
+            Tag.fromHex("5F20"),
+            "          ".encodeToByteArray(),
+        )
+        assertEquals(null, extractCardholderName(node))
+    }
+
+    @Test
+    fun `extractCardholderName returns null on an empty value`() {
+        val node = Tlv.Primitive(
+            Tag.fromHex("5F20"),
+            byteArrayOf(),
+        )
+        assertEquals(null, extractCardholderName(node))
+    }
+
+    @Test
+    fun `extractCardholderName decodes ISO-8859-1 high-byte characters correctly`() {
+        // "MÜLLER" in ISO-8859-1: M=0x4D, Ü=0xDC, L=0x4C, L=0x4C, E=0x45, R=0x52
+        val bytes = byteArrayOf(0x4D, 0xDC.toByte(), 0x4C, 0x4C, 0x45, 0x52)
+        val node = Tlv.Primitive(Tag.fromHex("5F20"), bytes)
+        assertEquals("MÜLLER", extractCardholderName(node))
+    }
+
+    @Test
+    fun `extractCardholderName decodes 0xFF as the highest Latin-1 codepoint`() {
+        val bytes = byteArrayOf(0xFF.toByte())
+        val node = Tlv.Primitive(Tag.fromHex("5F20"), bytes)
+        assertEquals("ÿ", extractCardholderName(node))
+    }
+
+    @Test
+    fun `extractApplicationLabel returns the trimmed ASCII string`() {
+        val node = Tlv.Primitive(
+            Tag.fromHex("50"),
+            "VISA".encodeToByteArray(),
+        )
+        assertEquals("VISA", extractApplicationLabel(node))
+    }
+
+    @Test
+    fun `extractApplicationLabel returns null on an all-spaces value`() {
+        val node = Tlv.Primitive(
+            Tag.fromHex("50"),
+            "    ".encodeToByteArray(),
+        )
+        assertEquals(null, extractApplicationLabel(node))
+    }
+
+    // ---- Track 2 ----
+
+    @Test
+    fun `extractTrack2 returns Track2 for a canonical Visa fixture`() {
+        val node = Tlv.Primitive(
+            Tag.fromHex("57"),
+            byteArrayOf(
+                0x41, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11,
+                0xD2.toByte(), 0x81.toByte(), 0x22, 0x01, 0x00, 0x00,
+            ),
+        )
+        val result = extractTrack2(node)
+        val ok = assertIs<ExtractResult.Ok<Track2>>(result)
+        assertEquals("4111111111111111", ok.value.pan.unmasked())
+    }
+
+    @Test
+    fun `extractTrack2 surfaces Track2Rejected on a missing separator`() {
+        val node = Tlv.Primitive(
+            Tag.fromHex("57"),
+            byteArrayOf(0x41, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11),
+        )
+        val result = extractTrack2(node)
+        val err = assertIs<ExtractResult.Err>(result)
+        val t2err = assertIs<EmvCardError.Track2Rejected>(err.error)
+        assertEquals(Track2Error.MissingSeparator, t2err.cause)
+    }
+}

--- a/shared/src/commonTest/kotlin/io/github/a7asoft/nfcemv/extract/internal/TlvSearchTest.kt
+++ b/shared/src/commonTest/kotlin/io/github/a7asoft/nfcemv/extract/internal/TlvSearchTest.kt
@@ -1,0 +1,62 @@
+package io.github.a7asoft.nfcemv.extract.internal
+
+import io.github.a7asoft.nfcemv.tlv.Tag
+import io.github.a7asoft.nfcemv.tlv.Tlv
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+
+class TlvSearchTest {
+
+    @Test
+    fun `findFirst returns a top-level primitive matching the tag`() {
+        val target = Tlv.Primitive(Tag.fromHex("5A"), byteArrayOf(0x41, 0x11))
+        val tlvs = listOf(
+            Tlv.Primitive(Tag.fromHex("4F"), byteArrayOf(0x01)),
+            target,
+        )
+        assertEquals(target, findFirst(tlvs, Tag.fromHex("5A")))
+    }
+
+    @Test
+    fun `findFirst recurses into a Constructed node`() {
+        val nested = Tlv.Primitive(Tag.fromHex("5A"), byteArrayOf(0x41, 0x11))
+        val tlvs = listOf(
+            Tlv.Constructed(Tag.fromHex("70"), listOf(nested)),
+        )
+        assertEquals(nested, findFirst(tlvs, Tag.fromHex("5A")))
+    }
+
+    @Test
+    fun `findFirst returns null when the tag is absent`() {
+        val tlvs = listOf(
+            Tlv.Primitive(Tag.fromHex("4F"), byteArrayOf(0x01)),
+        )
+        assertNull(findFirst(tlvs, Tag.fromHex("5A")))
+    }
+
+    @Test
+    fun `findFirst returns the first match in DFS order across siblings`() {
+        val first = Tlv.Primitive(Tag.fromHex("5A"), byteArrayOf(0x41))
+        val second = Tlv.Primitive(Tag.fromHex("5A"), byteArrayOf(0x42))
+        val tlvs = listOf(
+            Tlv.Constructed(Tag.fromHex("70"), listOf(first)),
+            second,
+        )
+        assertEquals(first, findFirst(tlvs, Tag.fromHex("5A")))
+    }
+
+    @Test
+    fun `findFirst returns null on an empty list`() {
+        assertNull(findFirst(emptyList(), Tag.fromHex("5A")))
+    }
+
+    @Test
+    fun `findFirst on a Constructed match returns the Constructed node itself`() {
+        val target = Tlv.Constructed(Tag.fromHex("70"), emptyList())
+        val tlvs = listOf<Tlv>(target)
+        val result = assertIs<Tlv.Constructed>(findFirst(tlvs, Tag.fromHex("70")))
+        assertEquals(target, result)
+    }
+}


### PR DESCRIPTION
## Summary

Closes the **v0.1.0 milestone** by composing every parser shipped in v0.1.0 → v0.1.5 into a single `EmvCard` data class and `EmvParser` entry points (`parse` / `parseOrThrow`). Last issue (#8); nothing in `commonMain` remains for the read-only contactless toolkit milestone.

Cherry-pick of develop's PR #30 squash (`3f1db0f`) onto `main` per the established Option A release pattern. No new code on this PR — reviewed under PR #30 by 4 agents (kotlin-architect, emv-nfc-expert, pci-security-reviewer, test-quality-reviewer) with all blockers (`EmvParser.parse` decomposition, BCD validation, `CENTURY_OFFSET` deviation doc, parser property fuzz) addressed before merge.

## Highlights

- `EmvCard` data class composing `pan: Pan`, `expiry: YearMonth`, `cardholderName: String?`, `brand: EmvBrand`, `applicationLabel: String?`, `track2: Track2?`, `aid: Aid`. `toString` masks PAN, Track 2, and cardholder name (`<N chars>`).
- `EmvParser.parse(apduResponses: List<ByteArray>): EmvCardResult` and `parseOrThrow` mirroring `Pan.parse` / `Track2.parse` patterns.
- `EmvCardError` sealed catalogue carrying only structural metadata — no raw value bytes anywhere.
- Tag `5A` PAN BCD validation surfaces typed `MalformedPanNibble(offset)` BEFORE `Pan.parse`.
- Tags `5F20` / `50` decode as ISO-8859-1 (cards like `MÜLLER` round-trip).
- `CENTURY_OFFSET = 2000` documented as deliberate v0.1.x deviation; pinned by regression tests at YY=00 and YY=99.
- 1000-iteration deterministic property fuzz on `EmvParser.parse` pinning the typed-result invariant.
- KDoc enumerates out-of-scope items: PSE/PPSE, multi-AID with tag `87` priority, `9F6B` Mastercard fallback, PAN agreement between `5A` and `57`, hardcoded `Strictness.Lenient`.

## Test plan

- [x] `:shared:allTests` green (iosSimulatorArm64 + Android debug + Android release)
- [x] No new `commonMain` API beyond what was reviewed under PR #30
- [x] CHANGELOG.md `[Unreleased]` block reflects v0.1.6 surface
- [x] No `Co-Authored-By` trailer
- [x] Plan files (`docs/superpowers/plans/`) untracked