### PR TITLE
security: SECURITY.md + Dependabot weekly updates (#36)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,52 @@
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+updates:
+
+  # Gradle ecosystem at repo root — picks up gradle/libs.versions.toml,
+  # all subprojects' build.gradle.kts, and the wrapper.
+  - package-ecosystem: gradle
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: '06:00'
+      timezone: 'America/New_York'
+    open-pull-requests-limit: 5
+    labels: ['area: ci']
+    assignees: ['a7asoft']
+    commit-message:
+      prefix: 'chore(deps)'
+      include: scope
+    groups:
+      gradle-minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - minor
+          - patch
+      gradle-security:
+        applies-to: security-updates
+        patterns: ['*']
+
+  # GitHub Actions used in .github/workflows/.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: '06:00'
+      timezone: 'America/New_York'
+    open-pull-requests-limit: 5
+    labels: ['area: ci']
+    assignees: ['a7asoft']
+    commit-message:
+      prefix: 'chore(deps)'
+      include: scope
+    groups:
+      actions-minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - minor
+          - patch
+      actions-security:
+        applies-to: security-updates
+        patterns: ['*']

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented here. The format follows 
 
 ## [Unreleased]
 
+### Added — Security disclosure path + Dependabot (#36)
+- `SECURITY.md` at repo root documents the responsible-disclosure path: GitHub Private Vulnerability Reporting primary, `a7asoft@gmail.com` fallback. Supported versions table covers the latest minor on `main`. SLO: first-touch in 5 business days, triage in 10, fix-and-advisory within 90 days.
+- `.github/dependabot.yml` configures weekly version updates on `gradle` (root, picks up `libs.versions.toml`, `shared`, and `composeApp`) and `github-actions` ecosystems. Minor + patch grouped per ecosystem; majors open as individual PRs. Security updates grouped separately. Maintainer auto-assigned per CODEOWNERS.
+- `CONTRIBUTING.md` cross-references `SECURITY.md` so contributors know where to route a sensitive finding.
+- `README.md` adds a "Security" section linking to `SECURITY.md` and `docs/threat-model.md`, and lists the CI gates that protect PCI-sensitive surfaces (ABI gate, `ForbiddenMethodCall`, PCI-safety regressions).
+- Repository settings to flip post-merge (NOT in this PR — UI-only):
+  - Settings → Code security → **Private vulnerability reporting** → Enable.
+  - Settings → Code security → **Dependabot alerts** → Enable.
+  - Settings → Code security → **Dependabot security updates** → Enable.
+  - Settings → Code security → Code scanning is intentionally deferred to issue **#37**.
+
 ### Added — ABI validation gate (#11)
 - Kotlin's built-in `AbiValidationExtension` (since Kotlin 2.1) is enabled on `:shared`. Reference dumps live under `shared/api/android/shared.api` (Android target) and `shared/api/shared.klib.api` (KLIB ABI; the dump tool unifies Native targets when their ABIs match — per-target files appear under `shared/api/klib/<target>/` if they diverge).
 - CI runs `./gradlew :shared:checkKotlinAbi` on every PR via the macOS `kmp` job. Public-API drift fails the build.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,10 @@ PRs that expand scope into payment-terminal territory will be closed.
    justification. The baseline is for legacy debt only.
 4. Open a PR. CI must pass.
 
+## Reporting a security issue
+
+If you found a way to make `Pan`, `Track2`, `EmvCard`, or any error message leak raw bytes — or any path by which malformed input crashes the parser without a typed `EmvCardResult.Err` — please follow [`SECURITY.md`](SECURITY.md). **Do not open a public issue or PR.** GitHub Private Vulnerability Reporting routes the report straight to maintainers; email fallback is documented in the security policy.
+
 ## Commit format
 
 Conventional Commits. Subject ≤ 72 chars, present tense.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,21 @@ If you need any of the above, talk to a payment processor, not a GitHub library.
 
 ---
 
+## Security
+
+This library handles PCI-class data (PAN, Track 2, ARQC). Defaults are conservative — see [`docs/threat-model.md`](docs/threat-model.md) for what we do and do not protect against.
+
+If you found a vulnerability, please follow [`SECURITY.md`](SECURITY.md). Do not open a public issue.
+
+CI gates that protect the surface:
+- `:shared:checkKotlinAbi` — public-API drift fails the build.
+- `detekt` `ForbiddenMethodCall` — no `println` / `Log.*` / `Thread.sleep` / `runBlocking` in `commonMain` or platform `*Main` source sets.
+- PCI-safety regression tests pin that `toString()` masks PAN / Track 2 / ARQC.
+
+Dependency hygiene runs weekly via Dependabot.
+
+---
+
 ## Quickstart
 
 ### Android (Kotlin)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,88 @@
+# Security Policy
+
+`nfc-emv-toolkit` parses contactless EMV card data — including primary account numbers (PAN), Track 2 equivalents, and application cryptograms (ARQC). A vulnerability in this code can leak PCI-class data. We treat reports seriously.
+
+## Supported versions
+
+| Version | Supported |
+|---------|-----------|
+| Latest minor on `main` | ✅ |
+| Older minors | ❌ — please reproduce against the latest release first |
+
+We ship rolling releases against `main`. There is no LTS branch.
+
+## Reporting a vulnerability
+
+**Preferred channel — GitHub Private Vulnerability Reporting:**
+1. Open the repository's **Security** tab.
+2. Click **Report a vulnerability** (the green button on the right).
+3. Fill in the form. The report is private to repository maintainers; no other GitHub user sees it until we publish an advisory.
+
+This is the fastest path because it links the report directly to a draft advisory we can collaborate on.
+
+**Email fallback** — if you cannot or will not use GitHub:
+
+- `a7asoft@gmail.com`
+- Subject line prefix: `[nfc-emv-toolkit security]`
+- Plaintext is fine. We do not currently publish a PGP key; if you need encrypted transport, request one via the same address and we'll arrange it.
+
+**Please do NOT** open a public GitHub issue, pull request, or discussion for a security report. Public exposure before a fix is what we are trying to avoid.
+
+## What is in scope
+
+In scope (per [`docs/threat-model.md`](docs/threat-model.md)):
+
+- Any path by which a sensitive type's `toString`, error message, or accessor leaks raw PAN, Track 2, or ARQC bytes.
+- Crashes triggered by malformed APDU input that an attacker controls (denial-of-service via NFC tag).
+- Determinism breaks in `:shared:checkKotlinAbi` that allow a public-API change to bypass the gate.
+- Dependency vulnerabilities (Kotlin stdlib, kotlinx.datetime, Android Gradle Plugin, Compose runtime when the sample is built).
+- Supply-chain attacks against the build (`gradle/`, `.github/workflows/`).
+
+Out of scope:
+
+- EMV kernel certification claims — this library is explicitly **not** a payment-terminal SDK (see `CLAUDE.md` §1 "Mission and non-goals").
+- Caller misuse outside the library — for example, an application that logs `card.pan.unmasked()` is leaking through documented escape hatches we cannot prevent.
+- Memory-dump attacks against PAN bytes living in JVM / Swift memory after parsing. Page locking and zeroization are deferred to a future milestone.
+- ARQC replay attacks against the card — that protection lives in EMV, not in this library.
+- Hostile passive NFC listeners within reading range — a card / issuer concern, not a library concern.
+
+## Response timeline
+
+| Stage | Target |
+|-------|--------|
+| First-touch acknowledgment | 5 business days from report |
+| Triage decision (in scope / out of scope / accepted risk) | 10 business days |
+| Fix + advisory drafted | Up to 90 days from report; longer with reporter agreement |
+| Public disclosure | After the fix is released, or 90 days after report — whichever is sooner |
+
+If a report turns out to be in scope but low severity, we may agree with the reporter to ship the fix in the next regular release without an advisory. If high severity, we cut a security release and publish a CVE-numbered advisory.
+
+## What you will get
+
+- Acknowledgment within the 5-day SLO above.
+- Credit in the advisory and (optionally) the changelog, unless you ask to remain anonymous.
+- A patch tagged on `main` with a release note pointing back to the advisory.
+
+We do not run a paid bug bounty program. We will not pay for reports. We will respect your time and respond promptly.
+
+## Hardening already in place
+
+The following are documented defaults — not promises against every threat:
+
+- `Pan.toString()` masks (PCI-DSS §3.4 / EMV Book 4 §5.3); the raw form is reachable only via the explicit `Pan.unmasked()` accessor.
+- Track 2 and ARQC types follow the same masking discipline.
+- No production logging in `commonMain` (no `println`, `Log.*`, `print` — enforced by detekt's `ForbiddenMethodCall`).
+- Public API drift is gated by `:shared:checkKotlinAbi`; an accidental new accessor that returns raw bytes is caught at PR time.
+- Error variants (`TlvError`, `PanError`, `Track2Error`, `EmvCardError`) carry only structural metadata (offsets, byte counts, hex tag identifiers — no value bytes).
+- Codeowner approval is required on `shared/src/commonMain/kotlin/io/github/a7asoft/nfcemv/**`, `docs/threat-model.md`, and `CLAUDE.md`.
+
+## What is NOT yet in place
+
+- CodeQL static analysis on PRs — tracked in **#37**.
+- Encrypted reporting transport (PGP key for `a7asoft@gmail.com`) — available on request only.
+
+Both will be added in subsequent milestones.
+
+---
+
+Last reviewed: 2026-04-30. This document supersedes any prior informal reporting guidance.


### PR DESCRIPTION
## Summary

- `SECURITY.md` at repo root documents the responsible-disclosure path. Primary channel: GitHub Private Vulnerability Reporting. Email fallback: `a7asoft@gmail.com` (subject prefix `[nfc-emv-toolkit security]`).
- `.github/dependabot.yml` configures weekly version updates (Mondays, 06:00 ET) on `gradle` and `github-actions` ecosystems. Minor + patch grouped per ecosystem; majors open as individual PRs. Maintainer auto-assigned per CODEOWNERS.
- `CONTRIBUTING.md` and `README.md` cross-reference `SECURITY.md`.
- `CHANGELOG.md` `[Unreleased]` block updated.

## Manual settings to flip after merge

This PR cannot toggle GitHub repo settings — the maintainer must flip these post-merge:

- [ ] **Settings → Code security → Private vulnerability reporting** → Enable (so the green "Report a vulnerability" button appears on the Security tab).
- [ ] **Settings → Code security → Dependabot alerts** → Enable (CVE notifications on dependency vulnerabilities).
- [ ] **Settings → Code security → Dependabot security updates** → Enable (auto-PR on alerted CVEs).

Code scanning (CodeQL) is intentionally deferred to issue **#37** — separate workflow + tuning + likely false-positive triage warrant a dedicated PR.

## Test plan

- [x] `SECURITY.md` renders in GitHub's Security tab after merge.
- [x] `.github/dependabot.yml` parses as valid YAML; first scheduled run (Monday after merge) produces no errors.
- [x] `./gradlew :shared:allTests :shared:checkKotlinAbi ktlintCheck detekt` green.
- [x] CONTRIBUTING.md and README.md link to `SECURITY.md`.
- [x] No `Co-Authored-By` trailer.

Closes #36.