### PR TITLE
feat(composeApp): integrate :android:reader with NfcAdapter foreground dispatch (#55)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,8 @@ jobs:
         run: ./gradlew :shared:allTests --stacktrace
       - name: Build and test android-reader module
         run: ./gradlew :android:reader:assembleDebug :android:reader:check --stacktrace
-      - name: Build Android sample
-        run: ./gradlew :composeApp:assembleDebug --stacktrace
+      - name: Build and test Android sample
+        run: ./gradlew :composeApp:testDebugUnitTest :composeApp:assembleDebug --stacktrace
 
   ios:
     name: iOS build & test

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -29,7 +29,6 @@ kotlin {
             implementation(libs.compose.uiToolingPreview)
             implementation(libs.androidx.lifecycle.viewmodelCompose)
             implementation(libs.androidx.lifecycle.runtimeCompose)
-            implementation(libs.kotlinx.datetime)
             implementation(projects.shared)
         }
         commonTest.dependencies {

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -18,6 +18,7 @@ kotlin {
         androidMain.dependencies {
             implementation(libs.compose.uiToolingPreview)
             implementation(libs.androidx.activity.compose)
+            implementation(projects.android.reader)
         }
         commonMain.dependencies {
             implementation(libs.compose.runtime)
@@ -28,10 +29,16 @@ kotlin {
             implementation(libs.compose.uiToolingPreview)
             implementation(libs.androidx.lifecycle.viewmodelCompose)
             implementation(libs.androidx.lifecycle.runtimeCompose)
+            implementation(libs.kotlinx.datetime)
             implementation(projects.shared)
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)
+        }
+        val androidUnitTest by getting {
+            dependencies {
+                implementation(libs.kotlinx.coroutines.test)
+            }
         }
     }
 }

--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <uses-permission android:name="android.permission.NFC" />
+    <uses-feature android:name="android.hardware.nfc" android:required="true" />
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
@@ -10,10 +13,10 @@
         android:theme="@android:style/Theme.Material.Light.NoActionBar">
         <activity
             android:exported="true"
-            android:name=".MainActivity">
+            android:name=".MainActivity"
+            android:configChanges="orientation|screenSize|keyboardHidden">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>

--- a/composeApp/src/androidMain/kotlin/io/github/a7asoft/App.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/a7asoft/App.kt
@@ -1,47 +1,31 @@
 package io.github.a7asoft
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.safeContentPadding
-import androidx.compose.material3.Button
+import android.content.Intent
+import android.provider.Settings
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
-import androidx.compose.runtime.*
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
-import nfc_emv_toolkit.composeapp.generated.resources.Res
-import nfc_emv_toolkit.composeapp.generated.resources.compose_multiplatform
-import org.jetbrains.compose.resources.painterResource
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.platform.LocalContext
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import io.github.a7asoft.ui.ReaderScreen
+import io.github.a7asoft.ui.ReaderViewModel
 
+/**
+ * Top-level composable that wires [ReaderViewModel.state] into
+ * [ReaderScreen]. Hoisted callbacks (`onTryAgain`, `onOpenNfcSettings`)
+ * keep the screen pure-presentation and unit-testable in isolation.
+ */
 @Composable
-@Preview
-fun App() {
+public fun App(viewModel: ReaderViewModel) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    val context = LocalContext.current
     MaterialTheme {
-        var showContent by remember { mutableStateOf(false) }
-        Column(
-            modifier = Modifier
-                .background(MaterialTheme.colorScheme.primaryContainer)
-                .safeContentPadding()
-                .fillMaxSize(),
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-            Button(onClick = { showContent = !showContent }) {
-                Text("Click me!")
-            }
-            AnimatedVisibility(showContent) {
-                Column(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                ) {
-                    Image(painterResource(Res.drawable.compose_multiplatform), null)
-                    Text("nfc-emv-toolkit sample")
-                }
-            }
-        }
+        ReaderScreen(
+            state = state,
+            onTryAgain = viewModel::reset,
+            onOpenNfcSettings = {
+                context.startActivity(Intent(Settings.ACTION_NFC_SETTINGS))
+            },
+        )
     }
 }

--- a/composeApp/src/androidMain/kotlin/io/github/a7asoft/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/a7asoft/MainActivity.kt
@@ -1,6 +1,7 @@
 package io.github.a7asoft
 
 import android.nfc.NfcAdapter
+import android.nfc.NfcManager
 import android.nfc.Tag
 import android.os.Bundle
 import androidx.activity.ComponentActivity
@@ -28,7 +29,11 @@ public class MainActivity : ComponentActivity() {
         ReaderViewModel.provideFactory(SystemNfcAvailability(applicationContext))
     }
 
-    private val nfcAdapter: NfcAdapter? by lazy { NfcAdapter.getDefaultAdapter(this) }
+    // why: NfcAdapter.getDefaultAdapter(Context) is deprecated since API 33;
+    // use the NfcManager system service. minSdk 24 covers getSystemService(Class).
+    private val nfcAdapter: NfcAdapter? by lazy {
+        getSystemService(NfcManager::class.java)?.defaultAdapter
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge()
@@ -39,7 +44,10 @@ public class MainActivity : ComponentActivity() {
     override fun onResume() {
         super.onResume()
         viewModel.refreshNfcAvailability()
-        nfcAdapter?.enableReaderMode(this, ::onTagDiscovered, READER_MODE_FLAGS, null)
+        val adapter = nfcAdapter
+        if (adapter != null && adapter.isEnabled) {
+            adapter.enableReaderMode(this, ::onTagDiscovered, READER_MODE_FLAGS, null)
+        }
     }
 
     override fun onPause() {

--- a/composeApp/src/androidMain/kotlin/io/github/a7asoft/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/a7asoft/MainActivity.kt
@@ -1,25 +1,61 @@
 package io.github.a7asoft
 
+import android.nfc.NfcAdapter
+import android.nfc.Tag
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.activity.viewModels
+import io.github.a7asoft.nfc.SystemNfcAvailability
+import io.github.a7asoft.nfcemv.reader.ContactlessReader
+import io.github.a7asoft.ui.ReaderHandle
+import io.github.a7asoft.ui.ReaderViewModel
 
-class MainActivity : ComponentActivity() {
+/**
+ * Entry-point activity. Owns NFC reader-mode lifecycle and hosts the
+ * Compose UI.
+ *
+ * NFC reader mode is enabled in [onResume] (reader callback delegates
+ * each detected [Tag] to the ViewModel via a [ReaderHandle]) and
+ * disabled in [onPause]. The activity declares
+ * `android:configChanges="orientation|screenSize|keyboardHidden"` in
+ * the manifest so rotation does not retoggle reader mode.
+ */
+public class MainActivity : ComponentActivity() {
+
+    private val viewModel: ReaderViewModel by viewModels {
+        ReaderViewModel.provideFactory(SystemNfcAvailability(applicationContext))
+    }
+
+    private val nfcAdapter: NfcAdapter? by lazy { NfcAdapter.getDefaultAdapter(this) }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
-
-        setContent {
-            App()
-        }
+        setContent { App(viewModel) }
     }
-}
 
-@Preview
-@Composable
-fun AppAndroidPreview() {
-    App()
+    override fun onResume() {
+        super.onResume()
+        viewModel.refreshNfcAvailability()
+        nfcAdapter?.enableReaderMode(this, ::onTagDiscovered, READER_MODE_FLAGS, null)
+    }
+
+    override fun onPause() {
+        super.onPause()
+        nfcAdapter?.disableReaderMode(this)
+    }
+
+    private fun onTagDiscovered(tag: Tag) {
+        viewModel.onReadRequested(ReaderHandle { ContactlessReader.fromTag(tag).read() })
+    }
+
+    private companion object {
+        // why: contactless EMV cards use ISO/IEC 14443 Type A or B. Skip
+        // NDEF since EMV records are not NDEF-formatted.
+        const val READER_MODE_FLAGS: Int = NfcAdapter.FLAG_READER_NFC_A or
+            NfcAdapter.FLAG_READER_NFC_B or
+            NfcAdapter.FLAG_READER_SKIP_NDEF_CHECK
+    }
 }

--- a/composeApp/src/androidMain/kotlin/io/github/a7asoft/nfc/NfcAvailability.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/a7asoft/nfc/NfcAvailability.kt
@@ -2,6 +2,7 @@ package io.github.a7asoft.nfc
 
 import android.content.Context
 import android.nfc.NfcAdapter
+import android.nfc.NfcManager
 
 /**
  * Categorical NFC capability state for UI display.
@@ -42,7 +43,10 @@ public class SystemNfcAvailability(context: Context) : NfcAvailability {
     private val applicationContext: Context = context.applicationContext
 
     override fun current(): NfcAvailabilityStatus {
-        val adapter = NfcAdapter.getDefaultAdapter(applicationContext)
+        // why: NfcAdapter.getDefaultAdapter(Context) is deprecated since
+        // API 33; use the NfcManager system service. minSdk 24 covers
+        // getSystemService(Class).
+        val adapter = applicationContext.getSystemService(NfcManager::class.java)?.defaultAdapter
             ?: return NfcAvailabilityStatus.Unavailable
         return if (adapter.isEnabled) NfcAvailabilityStatus.Available else NfcAvailabilityStatus.Disabled
     }

--- a/composeApp/src/androidMain/kotlin/io/github/a7asoft/nfc/NfcAvailability.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/a7asoft/nfc/NfcAvailability.kt
@@ -1,0 +1,49 @@
+package io.github.a7asoft.nfc
+
+import android.content.Context
+import android.nfc.NfcAdapter
+
+/**
+ * Categorical NFC capability state for UI display.
+ *
+ * Mapped from the platform `NfcAdapter` API; abstracted via [NfcAvailability]
+ * so the ViewModel can be unit-tested without Robolectric or a real device.
+ */
+public sealed interface NfcAvailabilityStatus {
+
+    /** Device has no NFC hardware. App cannot read cards. */
+    public data object Unavailable : NfcAvailabilityStatus
+
+    /** NFC hardware exists but is disabled in system settings. User can fix. */
+    public data object Disabled : NfcAvailabilityStatus
+
+    /** NFC hardware exists and is enabled. Ready to read. */
+    public data object Available : NfcAvailabilityStatus
+}
+
+/**
+ * Abstraction over platform NFC capability checks. Production impl is
+ * [SystemNfcAvailability]; tests inject a fake.
+ */
+public fun interface NfcAvailability {
+    /** Snapshot the current device NFC capability state. */
+    public fun current(): NfcAvailabilityStatus
+}
+
+/**
+ * Production [NfcAvailability] backed by [NfcAdapter].
+ *
+ * Captures the [Context] only as an Application context so it cannot
+ * leak Activity references. Re-checks on every [current] call so the
+ * ViewModel can see system-settings changes after `onResume`.
+ */
+public class SystemNfcAvailability(context: Context) : NfcAvailability {
+
+    private val applicationContext: Context = context.applicationContext
+
+    override fun current(): NfcAvailabilityStatus {
+        val adapter = NfcAdapter.getDefaultAdapter(applicationContext)
+            ?: return NfcAvailabilityStatus.Unavailable
+        return if (adapter.isEnabled) NfcAvailabilityStatus.Available else NfcAvailabilityStatus.Disabled
+    }
+}

--- a/composeApp/src/androidMain/kotlin/io/github/a7asoft/ui/ReaderHandle.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/a7asoft/ui/ReaderHandle.kt
@@ -1,0 +1,18 @@
+package io.github.a7asoft.ui
+
+import io.github.a7asoft.nfcemv.reader.ReaderState
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Single-method abstraction over a contactless read driver.
+ *
+ * Decouples [ReaderViewModel] from `android.nfc.Tag`: production wiring
+ * (`MainActivity`) wraps a `Tag` in a handle that calls
+ * `ContactlessReader.fromTag(tag).read()`; unit tests pass
+ * `ReaderHandle { flowOf(...) }` directly. This is what makes the
+ * ViewModel testable without Robolectric.
+ */
+public fun interface ReaderHandle {
+    /** Drive a single contactless read; emits one [ReaderState] per stage. */
+    public fun read(): Flow<ReaderState>
+}

--- a/composeApp/src/androidMain/kotlin/io/github/a7asoft/ui/ReaderScreen.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/a7asoft/ui/ReaderScreen.kt
@@ -1,0 +1,54 @@
+package io.github.a7asoft.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import io.github.a7asoft.ui.components.CardSummary
+import io.github.a7asoft.ui.components.ErrorPanel
+import io.github.a7asoft.ui.components.ReadingProgress
+import io.github.a7asoft.ui.components.StatusHeader
+
+/**
+ * Pure-presentation screen for the reader flow.
+ *
+ * State and callbacks are hoisted; the screen renders only what the
+ * caller passes. Test by passing a fake [ReaderUiState] and asserting
+ * which sub-composable is shown.
+ */
+@Composable
+public fun ReaderScreen(
+    state: ReaderUiState,
+    onTryAgain: () -> Unit,
+    onOpenNfcSettings: () -> Unit,
+) {
+    Surface(modifier = Modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier.padding(24.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            StatusHeader(state, onOpenNfcSettings)
+            ReaderContent(state, onTryAgain)
+        }
+    }
+}
+
+@Composable
+@Suppress("CyclomaticComplexMethod")
+// why: exhaustive `when` over the sealed `ReaderUiState` catalogue. Each
+// branch is a single mapping, not an arm of real cyclomatic complexity.
+private fun ReaderContent(state: ReaderUiState, onTryAgain: () -> Unit) {
+    when (state) {
+        ReaderUiState.NfcUnavailable, ReaderUiState.NfcDisabled, ReaderUiState.Idle -> Unit
+        ReaderUiState.TagDetected -> ReadingProgress(stageLabel = "Tag detected")
+        ReaderUiState.SelectingPpse -> ReadingProgress(stageLabel = "Selecting application directory")
+        is ReaderUiState.SelectingApplication -> ReadingProgress(stageLabel = "Selecting application ${state.aid}")
+        ReaderUiState.ReadingRecords -> ReadingProgress(stageLabel = "Reading records")
+        is ReaderUiState.Done -> CardSummary(card = state.card, onTryAgain = onTryAgain)
+        is ReaderUiState.Failed -> ErrorPanel(error = state.error, onTryAgain = onTryAgain)
+    }
+}

--- a/composeApp/src/androidMain/kotlin/io/github/a7asoft/ui/ReaderUiState.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/a7asoft/ui/ReaderUiState.kt
@@ -1,0 +1,45 @@
+package io.github.a7asoft.ui
+
+import io.github.a7asoft.nfcemv.brand.Aid
+import io.github.a7asoft.nfcemv.extract.EmvCard
+import io.github.a7asoft.nfcemv.reader.ReaderError
+
+/**
+ * UI-mapped state for the reader screen.
+ *
+ * Combines NFC availability gates and the underlying
+ * `io.github.a7asoft.nfcemv.reader.ReaderState` flow into a single
+ * sealed catalogue so [ReaderScreen] renders from one source of truth.
+ *
+ * The mapping happens in [ReaderViewModel]; this file only declares the
+ * shape.
+ */
+public sealed interface ReaderUiState {
+
+    /** Device has no NFC hardware. Permanent "this app needs NFC" message. */
+    public data object NfcUnavailable : ReaderUiState
+
+    /** NFC is off in system settings. Show "Open NFC settings" CTA. */
+    public data object NfcDisabled : ReaderUiState
+
+    /** Ready to read. UI prompts "Tap a card to read". */
+    public data object Idle : ReaderUiState
+
+    /** Tag was just detected. UI shows initial progress. */
+    public data object TagDetected : ReaderUiState
+
+    /** Reader is in PPSE select stage. */
+    public data object SelectingPpse : ReaderUiState
+
+    /** Reader chose an AID and is selecting it. UI shows the AID hex. */
+    public data class SelectingApplication(public val aid: Aid) : ReaderUiState
+
+    /** Reader is iterating AFL records. */
+    public data object ReadingRecords : ReaderUiState
+
+    /** Read succeeded. UI displays the parsed [EmvCard]. */
+    public data class Done(public val card: EmvCard) : ReaderUiState
+
+    /** Read failed. UI displays a friendly message + diagnostic detail. */
+    public data class Failed(public val error: ReaderError) : ReaderUiState
+}

--- a/composeApp/src/androidMain/kotlin/io/github/a7asoft/ui/ReaderViewModel.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/a7asoft/ui/ReaderViewModel.kt
@@ -1,0 +1,104 @@
+package io.github.a7asoft.ui
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import io.github.a7asoft.nfc.NfcAvailability
+import io.github.a7asoft.nfc.NfcAvailabilityStatus
+import io.github.a7asoft.nfcemv.reader.ReaderState
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Owns the [ReaderUiState] for the reader screen.
+ *
+ * Plain [ViewModel] (not [androidx.lifecycle.AndroidViewModel]) so it
+ * can be unit-tested without Robolectric. Platform-specific dependencies
+ * ([NfcAvailability], the [ReaderHandle] per read) are injected via the
+ * [provideFactory] builder and the public API.
+ *
+ * Concurrency contract: only one read flow runs at a time. A new
+ * [onReadRequested] cancels any in-flight collection before starting
+ * the new one (defensive against rapid taps).
+ */
+public class ReaderViewModel internal constructor(
+    private val nfcAvailability: NfcAvailability,
+) : ViewModel() {
+
+    private val _state: MutableStateFlow<ReaderUiState> = MutableStateFlow(initialState())
+
+    /** Current UI state. UI cannot mutate; only [onReadRequested] / [reset] / [refreshNfcAvailability] do. */
+    public val state: StateFlow<ReaderUiState> = _state.asStateFlow()
+
+    private val activeRead: AtomicReference<Job?> = AtomicReference(null)
+
+    /** Re-check NFC availability — call from MainActivity.onResume. */
+    public fun refreshNfcAvailability() {
+        if (_state.value is ReaderUiState.Done || _state.value is ReaderUiState.Failed) return
+        _state.value = initialState()
+    }
+
+    /** Begin a read using [handle]. Cancels any in-flight read first. */
+    public fun onReadRequested(handle: ReaderHandle) {
+        if (_state.value !is ReaderUiState.Idle) return
+        activeRead.getAndSet(null)?.cancel()
+        val job = handle.read()
+            .onEach { state -> _state.value = mapReaderState(state) }
+            .launchIn(viewModelScope)
+        activeRead.set(job)
+    }
+
+    /** Reset to the initial state after a Done/Failed terminal. */
+    public fun reset() {
+        activeRead.getAndSet(null)?.cancel()
+        _state.value = initialState()
+    }
+
+    override fun onCleared() {
+        activeRead.getAndSet(null)?.cancel()
+        super.onCleared()
+    }
+
+    @Suppress("CyclomaticComplexMethod")
+    // why: exhaustive `when` over the sealed [NfcAvailabilityStatus] catalogue.
+    // Each branch is a single mapping, not real cyclomatic complexity.
+    private fun initialState(): ReaderUiState = when (nfcAvailability.current()) {
+        NfcAvailabilityStatus.Unavailable -> ReaderUiState.NfcUnavailable
+        NfcAvailabilityStatus.Disabled -> ReaderUiState.NfcDisabled
+        NfcAvailabilityStatus.Available -> ReaderUiState.Idle
+    }
+
+    @Suppress("CyclomaticComplexMethod")
+    // why: exhaustive `when` over the sealed `ReaderState` catalogue is the
+    // project idiom (CLAUDE.md §3.2). Each branch is a single mapping, not
+    // an arm of real cyclomatic complexity.
+    private fun mapReaderState(state: ReaderState): ReaderUiState = when (state) {
+        is ReaderState.TagDetected -> ReaderUiState.TagDetected
+        is ReaderState.SelectingPpse -> ReaderUiState.SelectingPpse
+        is ReaderState.SelectingAid -> ReaderUiState.SelectingApplication(state.aid)
+        is ReaderState.ReadingRecords -> ReaderUiState.ReadingRecords
+        is ReaderState.Done -> ReaderUiState.Done(state.card)
+        is ReaderState.Failed -> ReaderUiState.Failed(state.error)
+    }
+
+    public companion object {
+        /**
+         * Build the production-wired [ViewModelProvider.Factory].
+         *
+         * @param availability NFC capability checker (typically
+         *   [io.github.a7asoft.nfc.SystemNfcAvailability]).
+         */
+        public fun provideFactory(
+            availability: NfcAvailability,
+        ): ViewModelProvider.Factory = viewModelFactory {
+            initializer { ReaderViewModel(availability) }
+        }
+    }
+}

--- a/composeApp/src/androidMain/kotlin/io/github/a7asoft/ui/ReaderViewModel.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/a7asoft/ui/ReaderViewModel.kt
@@ -7,11 +7,14 @@ import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import io.github.a7asoft.nfc.NfcAvailability
 import io.github.a7asoft.nfc.NfcAvailabilityStatus
+import io.github.a7asoft.nfcemv.reader.IoReason
+import io.github.a7asoft.nfcemv.reader.ReaderError
 import io.github.a7asoft.nfcemv.reader.ReaderState
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import java.util.concurrent.atomic.AtomicReference
@@ -39,18 +42,48 @@ public class ReaderViewModel internal constructor(
 
     private val activeRead: AtomicReference<Job?> = AtomicReference(null)
 
-    /** Re-check NFC availability — call from MainActivity.onResume. */
+    /**
+     * Re-check NFC availability — call from `MainActivity.onResume`.
+     *
+     * Only refreshes when state is one of the resettable gates
+     * ([ReaderUiState.NfcUnavailable], [ReaderUiState.NfcDisabled],
+     * [ReaderUiState.Idle]). In-flight reads (TagDetected … ReadingRecords)
+     * and terminal states (Done, Failed) are preserved so the user does
+     * not lose progress or results when returning from system settings.
+     */
+    @Suppress("CyclomaticComplexMethod")
+    // why: 3-branch sealed dispatch over the resettable subset of
+    // [ReaderUiState]; detekt counts the function itself as +1, tipping
+    // the threshold. The suppression matches that algorithm.
     public fun refreshNfcAvailability() {
-        if (_state.value is ReaderUiState.Done || _state.value is ReaderUiState.Failed) return
-        _state.value = initialState()
+        val current = _state.value
+        val refreshable = current is ReaderUiState.NfcUnavailable ||
+            current is ReaderUiState.NfcDisabled ||
+            current is ReaderUiState.Idle
+        if (refreshable) _state.value = initialState()
     }
 
-    /** Begin a read using [handle]. Cancels any in-flight read first. */
+    /**
+     * Begin a read using [handle]. Cancels any in-flight read first.
+     *
+     * Uses an atomic Idle → TagDetected transition to guard against
+     * concurrent invocations from NFC reader-mode binder-thread callbacks
+     * (a TOCTOU race that a plain `if (state is Idle)` check cannot
+     * defend against).
+     */
     public fun onReadRequested(handle: ReaderHandle) {
-        if (_state.value !is ReaderUiState.Idle) return
+        // why: atomic gate. NFC reader-mode callbacks fire on a binder
+        // thread, not main; two concurrent taps could both pass a naive
+        // `is Idle` check. compareAndSet is the smallest defensible fix.
+        // The flow's first emission may overwrite TagDetected with the
+        // same TagDetected (or the next state) — UI effect is identical.
+        if (!_state.compareAndSet(ReaderUiState.Idle, ReaderUiState.TagDetected)) return
         activeRead.getAndSet(null)?.cancel()
         val job = handle.read()
             .onEach { state -> _state.value = mapReaderState(state) }
+            // why: defensive. Any unexpected upstream throw should land as
+            // Failed, not propagate to viewModelScope's exception handler.
+            .catch { _state.value = ReaderUiState.Failed(ReaderError.IoFailure(IoReason.Generic)) }
             .launchIn(viewModelScope)
         activeRead.set(job)
     }
@@ -67,8 +100,9 @@ public class ReaderViewModel internal constructor(
     }
 
     @Suppress("CyclomaticComplexMethod")
-    // why: exhaustive `when` over the sealed [NfcAvailabilityStatus] catalogue.
-    // Each branch is a single mapping, not real cyclomatic complexity.
+    // why: 3-branch sealed dispatch over [NfcAvailabilityStatus]. detekt's
+    // branch-counting algorithm re-flags this at threshold 4; the
+    // suppression matches that algorithm.
     private fun initialState(): ReaderUiState = when (nfcAvailability.current()) {
         NfcAvailabilityStatus.Unavailable -> ReaderUiState.NfcUnavailable
         NfcAvailabilityStatus.Disabled -> ReaderUiState.NfcDisabled

--- a/composeApp/src/androidMain/kotlin/io/github/a7asoft/ui/components/CardSummary.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/a7asoft/ui/components/CardSummary.kt
@@ -1,0 +1,53 @@
+package io.github.a7asoft.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import io.github.a7asoft.nfcemv.extract.EmvCard
+
+/**
+ * Renders an [EmvCard] using only its safe accessors:
+ * - `pan.toString()` (always masked per [io.github.a7asoft.nfcemv.extract.Pan]).
+ * - `brand.displayName` (human-readable label per
+ *   [io.github.a7asoft.nfcemv.brand.EmvBrand]).
+ * - `expiry`, `cardholderName?`, `applicationLabel?`, `aid` — non-PCI
+ *   operational metadata.
+ *
+ * NEVER calls `pan.unmasked()` — sample app explicitly does not show
+ * raw PAN even with the card in hand.
+ */
+@Composable
+public fun CardSummary(card: EmvCard, onTryAgain: () -> Unit) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Field(label = "PAN", value = card.pan.toString())
+            Field(label = "Brand", value = card.brand.displayName)
+            Field(label = "Expiry", value = card.expiry.toString())
+            Field(label = "Cardholder", value = card.cardholderName ?: "<not provided>")
+            Field(label = "Label", value = card.applicationLabel ?: "<not provided>")
+            Field(label = "AID", value = card.aid.toString())
+            OutlinedButton(onClick = onTryAgain, modifier = Modifier.fillMaxWidth()) {
+                Text("Read another card")
+            }
+        }
+    }
+}
+
+@Composable
+private fun Field(label: String, value: String) {
+    Column {
+        Text(text = label, style = MaterialTheme.typography.labelSmall)
+        Text(text = value, style = MaterialTheme.typography.bodyMedium)
+    }
+}

--- a/composeApp/src/androidMain/kotlin/io/github/a7asoft/ui/components/ErrorPanel.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/a7asoft/ui/components/ErrorPanel.kt
@@ -1,0 +1,70 @@
+package io.github.a7asoft.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import io.github.a7asoft.nfcemv.reader.IoReason
+import io.github.a7asoft.nfcemv.reader.ReaderError
+
+/**
+ * Renders a [ReaderError] as a friendly headline plus a collapsible
+ * diagnostic detail (`error.toString()`) and a "Try again" CTA.
+ *
+ * `error.toString()` is safe to display: every [ReaderError] variant
+ * carries only structural metadata (status words, structural sub-error
+ * references, [IoReason] enum) — never raw card bytes or arbitrary
+ * exception messages.
+ */
+@Composable
+public fun ErrorPanel(error: ReaderError, onTryAgain: () -> Unit) {
+    val expandedState = remember { mutableStateOf(false) }
+    val expanded = expandedState.value
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.errorContainer),
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Text(text = friendlyMessage(error), style = MaterialTheme.typography.titleMedium)
+            OutlinedButton(onClick = { expandedState.value = !expanded }) {
+                Text(if (expanded) "Hide details" else "Show details")
+            }
+            if (expanded) {
+                Text(text = error.toString(), style = MaterialTheme.typography.bodySmall)
+            }
+            OutlinedButton(onClick = onTryAgain, modifier = Modifier.fillMaxWidth()) {
+                Text("Try again")
+            }
+        }
+    }
+}
+
+@Suppress("CyclomaticComplexMethod")
+// why: exhaustive when over sealed [ReaderError] + [IoReason]. Each branch
+// is a single mapping, not real complexity.
+private fun friendlyMessage(error: ReaderError): String = when (error) {
+    is ReaderError.IoFailure -> when (error.reason) {
+        IoReason.TagLost -> "The card was moved away too quickly. Hold it steady."
+        IoReason.Timeout -> "The card took too long to respond. Try again."
+        IoReason.Generic -> "Communication with the card failed."
+    }
+    ReaderError.PpseUnsupported -> "This card does not advertise a contactless EMV directory."
+    ReaderError.NoApplicationSelected -> "The card listed no contactless applications."
+    is ReaderError.ApduStatusError -> "The card returned an unexpected status."
+    is ReaderError.PpseRejected -> "The PPSE response could not be parsed."
+    is ReaderError.GpoRejected -> "The GET PROCESSING OPTIONS response could not be parsed."
+    is ReaderError.ParseFailed -> "The card data could not be parsed into an EMV card."
+}

--- a/composeApp/src/androidMain/kotlin/io/github/a7asoft/ui/components/ErrorPanel.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/a7asoft/ui/components/ErrorPanel.kt
@@ -39,7 +39,7 @@ public fun ErrorPanel(error: ReaderError, onTryAgain: () -> Unit) {
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             Text(text = friendlyMessage(error), style = MaterialTheme.typography.titleMedium)
-            OutlinedButton(onClick = { expandedState.value = !expanded }) {
+            OutlinedButton(onClick = { expandedState.value = !expandedState.value }) {
                 Text(if (expanded) "Hide details" else "Show details")
             }
             if (expanded) {
@@ -53,18 +53,24 @@ public fun ErrorPanel(error: ReaderError, onTryAgain: () -> Unit) {
 }
 
 @Suppress("CyclomaticComplexMethod")
-// why: exhaustive when over sealed [ReaderError] + [IoReason]. Each branch
-// is a single mapping, not real complexity.
+// why: exhaustive when over sealed [ReaderError] catalogue. Each branch is
+// a single mapping, not real complexity.
 private fun friendlyMessage(error: ReaderError): String = when (error) {
-    is ReaderError.IoFailure -> when (error.reason) {
-        IoReason.TagLost -> "The card was moved away too quickly. Hold it steady."
-        IoReason.Timeout -> "The card took too long to respond. Try again."
-        IoReason.Generic -> "Communication with the card failed."
-    }
+    is ReaderError.IoFailure -> friendlyIoMessage(error.reason)
     ReaderError.PpseUnsupported -> "This card does not advertise a contactless EMV directory."
     ReaderError.NoApplicationSelected -> "The card listed no contactless applications."
     is ReaderError.ApduStatusError -> "The card returned an unexpected status."
     is ReaderError.PpseRejected -> "The PPSE response could not be parsed."
     is ReaderError.GpoRejected -> "The GET PROCESSING OPTIONS response could not be parsed."
     is ReaderError.ParseFailed -> "The card data could not be parsed into an EMV card."
+}
+
+@Suppress("CyclomaticComplexMethod")
+// why: 3-branch sealed dispatch over [IoReason]; detekt counts the
+// function itself as +1, tipping the threshold. The suppression matches
+// that algorithm.
+private fun friendlyIoMessage(reason: IoReason): String = when (reason) {
+    IoReason.TagLost -> "The card was moved away too quickly. Hold it steady."
+    IoReason.Timeout -> "The card took too long to respond. Try again."
+    IoReason.Generic -> "Communication with the card failed."
 }

--- a/composeApp/src/androidMain/kotlin/io/github/a7asoft/ui/components/ReadingProgress.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/a7asoft/ui/components/ReadingProgress.kt
@@ -1,0 +1,27 @@
+package io.github.a7asoft.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+/**
+ * Linear-progress + stage-label pair shown during the read flow. The
+ * caller passes a human-readable [stageLabel] derived from the current
+ * `ReaderUiState`.
+ */
+@Composable
+public fun ReadingProgress(stageLabel: String) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+        Text(text = stageLabel, style = MaterialTheme.typography.bodyMedium)
+    }
+}

--- a/composeApp/src/androidMain/kotlin/io/github/a7asoft/ui/components/StatusHeader.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/a7asoft/ui/components/StatusHeader.kt
@@ -44,25 +44,37 @@ public fun StatusHeader(
 }
 
 @Suppress("CyclomaticComplexMethod")
-// why: exhaustive when over sealed UI state; intermediate progress states
-// collapse via `else ->`. Each branch is a single mapping.
+// why: exhaustive when over sealed UI state. Intermediate progress states
+// share text but are listed explicitly so adding a new state to
+// ReaderUiState produces a compile error here, preserving exhaustiveness
+// (CLAUDE.md §3.2). Each branch is a single mapping.
 private fun headlineFor(state: ReaderUiState): String = when (state) {
     ReaderUiState.NfcUnavailable -> "NFC not supported"
     ReaderUiState.NfcDisabled -> "NFC is off"
     ReaderUiState.Idle -> "Tap a card"
     is ReaderUiState.Done -> "Card read"
     is ReaderUiState.Failed -> "Read failed"
-    else -> "Reading"
+    ReaderUiState.TagDetected,
+    ReaderUiState.SelectingPpse,
+    is ReaderUiState.SelectingApplication,
+    ReaderUiState.ReadingRecords,
+    -> "Reading"
 }
 
 @Suppress("CyclomaticComplexMethod")
-// why: exhaustive when over sealed UI state; intermediate progress states
-// collapse via `else ->`. Each branch is a single mapping.
+// why: exhaustive when over sealed UI state. Intermediate progress states
+// share text but are listed explicitly so adding a new state to
+// ReaderUiState produces a compile error here, preserving exhaustiveness
+// (CLAUDE.md §3.2). Each branch is a single mapping.
 private fun subtitleFor(state: ReaderUiState): String = when (state) {
     ReaderUiState.NfcUnavailable -> "This device has no NFC hardware. The reader cannot run here."
     ReaderUiState.NfcDisabled -> "Enable NFC in system settings to read a card."
     ReaderUiState.Idle -> "Hold a contactless EMV card against the back of the device."
     is ReaderUiState.Done -> "Hold another card to read again."
     is ReaderUiState.Failed -> "Try again, or use a different card."
-    else -> "Hold the card steady"
+    ReaderUiState.TagDetected,
+    ReaderUiState.SelectingPpse,
+    is ReaderUiState.SelectingApplication,
+    ReaderUiState.ReadingRecords,
+    -> "Hold the card steady"
 }

--- a/composeApp/src/androidMain/kotlin/io/github/a7asoft/ui/components/StatusHeader.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/a7asoft/ui/components/StatusHeader.kt
@@ -1,0 +1,68 @@
+package io.github.a7asoft.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import io.github.a7asoft.ui.ReaderUiState
+
+/**
+ * Top region of the reader screen. Shows a state-driven headline and
+ * subtitle, plus an "Open NFC settings" CTA when NFC is disabled.
+ */
+@Composable
+public fun StatusHeader(
+    state: ReaderUiState,
+    onOpenNfcSettings: () -> Unit,
+) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Text(
+            text = headlineFor(state),
+            style = MaterialTheme.typography.headlineSmall,
+            textAlign = TextAlign.Center,
+        )
+        Text(
+            text = subtitleFor(state),
+            style = MaterialTheme.typography.bodyMedium,
+            textAlign = TextAlign.Center,
+        )
+        if (state is ReaderUiState.NfcDisabled) {
+            Button(onClick = onOpenNfcSettings) { Text("Open NFC settings") }
+        }
+    }
+}
+
+@Suppress("CyclomaticComplexMethod")
+// why: exhaustive when over sealed UI state; intermediate progress states
+// collapse via `else ->`. Each branch is a single mapping.
+private fun headlineFor(state: ReaderUiState): String = when (state) {
+    ReaderUiState.NfcUnavailable -> "NFC not supported"
+    ReaderUiState.NfcDisabled -> "NFC is off"
+    ReaderUiState.Idle -> "Tap a card"
+    is ReaderUiState.Done -> "Card read"
+    is ReaderUiState.Failed -> "Read failed"
+    else -> "Reading"
+}
+
+@Suppress("CyclomaticComplexMethod")
+// why: exhaustive when over sealed UI state; intermediate progress states
+// collapse via `else ->`. Each branch is a single mapping.
+private fun subtitleFor(state: ReaderUiState): String = when (state) {
+    ReaderUiState.NfcUnavailable -> "This device has no NFC hardware. The reader cannot run here."
+    ReaderUiState.NfcDisabled -> "Enable NFC in system settings to read a card."
+    ReaderUiState.Idle -> "Hold a contactless EMV card against the back of the device."
+    is ReaderUiState.Done -> "Hold another card to read again."
+    is ReaderUiState.Failed -> "Try again, or use a different card."
+    else -> "Hold the card steady"
+}

--- a/composeApp/src/androidUnitTest/kotlin/io/github/a7asoft/ui/FakeNfcAvailability.kt
+++ b/composeApp/src/androidUnitTest/kotlin/io/github/a7asoft/ui/FakeNfcAvailability.kt
@@ -1,0 +1,13 @@
+package io.github.a7asoft.ui
+
+import io.github.a7asoft.nfc.NfcAvailability
+import io.github.a7asoft.nfc.NfcAvailabilityStatus
+import java.util.concurrent.atomic.AtomicReference
+
+internal class FakeNfcAvailability(initial: NfcAvailabilityStatus) : NfcAvailability {
+    private val current: AtomicReference<NfcAvailabilityStatus> = AtomicReference(initial)
+    override fun current(): NfcAvailabilityStatus = current.get()
+    fun set(status: NfcAvailabilityStatus) {
+        current.set(status)
+    }
+}

--- a/composeApp/src/androidUnitTest/kotlin/io/github/a7asoft/ui/ReaderViewModelTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/io/github/a7asoft/ui/ReaderViewModelTest.kt
@@ -8,6 +8,7 @@ import io.github.a7asoft.nfcemv.reader.ReaderError
 import io.github.a7asoft.nfcemv.reader.ReaderState
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
@@ -90,11 +91,38 @@ class ReaderViewModelTest {
     }
 
     @Test
+    fun `onReadRequested is ignored when state is mid read`() = runTest {
+        val flow = MutableSharedFlow<ReaderState>(replay = 1).also { it.tryEmit(ReaderState.TagDetected) }
+        val vm = ReaderViewModel(
+            nfcAvailability = FakeNfcAvailability(NfcAvailabilityStatus.Available),
+        )
+        vm.onReadRequested(ReaderHandle { flow })
+        assertEquals(ReaderUiState.TagDetected, vm.state.value)
+        vm.onReadRequested(ReaderHandle { flowOf(ReaderState.Done(sampleCard())) })
+        assertEquals(ReaderUiState.TagDetected, vm.state.value)
+    }
+
+    @Test
     fun `reset returns to Idle from Done`() = runTest {
         val vm = ReaderViewModel(
             nfcAvailability = FakeNfcAvailability(NfcAvailabilityStatus.Available),
         )
         vm.onReadRequested(ReaderHandle { flowOf(ReaderState.Done(sampleCard())) })
+        vm.reset()
+        assertEquals(ReaderUiState.Idle, vm.state.value)
+    }
+
+    @Test
+    fun `reset returns to Idle from Failed`() = runTest {
+        val vm = ReaderViewModel(
+            nfcAvailability = FakeNfcAvailability(NfcAvailabilityStatus.Available),
+        )
+        vm.onReadRequested(
+            ReaderHandle {
+                flowOf(ReaderState.TagDetected, ReaderState.Failed(ReaderError.PpseUnsupported))
+            },
+        )
+        require(vm.state.value is ReaderUiState.Failed) { "precondition failed: state must be Failed" }
         vm.reset()
         assertEquals(ReaderUiState.Idle, vm.state.value)
     }
@@ -108,6 +136,34 @@ class ReaderViewModelTest {
         assertEquals(ReaderUiState.Idle, vm.state.value)
     }
 
+    @Test
+    fun `refreshNfcAvailability preserves Done state`() = runTest {
+        val availability = FakeNfcAvailability(NfcAvailabilityStatus.Available)
+        val vm = ReaderViewModel(nfcAvailability = availability)
+        vm.onReadRequested(ReaderHandle { flowOf(ReaderState.Done(sampleCard())) })
+        val before = vm.state.value
+        require(before is ReaderUiState.Done) { "precondition failed: state must be Done" }
+        availability.set(NfcAvailabilityStatus.Disabled)
+        vm.refreshNfcAvailability()
+        assertEquals(before, vm.state.value)
+    }
+
+    @Test
+    fun `refreshNfcAvailability preserves Failed state`() = runTest {
+        val availability = FakeNfcAvailability(NfcAvailabilityStatus.Available)
+        val vm = ReaderViewModel(nfcAvailability = availability)
+        vm.onReadRequested(
+            ReaderHandle {
+                flowOf(ReaderState.TagDetected, ReaderState.Failed(ReaderError.PpseUnsupported))
+            },
+        )
+        val before = vm.state.value
+        require(before is ReaderUiState.Failed) { "precondition failed: state must be Failed" }
+        availability.set(NfcAvailabilityStatus.Disabled)
+        vm.refreshNfcAvailability()
+        assertEquals(before, vm.state.value)
+    }
+
     private fun vm(status: NfcAvailabilityStatus): ReaderViewModel = ReaderViewModel(
         nfcAvailability = FakeNfcAvailability(status),
     )
@@ -118,6 +174,9 @@ class ReaderViewModelTest {
     // module's tests. We rebuild it by parsing the canonical Visa fixture
     // bytes (verbatim copy of `:shared:commonTest:Fixtures.VISA_CLASSIC`).
     // EmvParser.parseOrThrow is the supported construction path.
+    //
+    // KEEP IN SYNC: if Fixtures.VISA_CLASSIC bytes change in :shared,
+    // update this constant too. There is no compile-time link.
     private fun sampleCard(): EmvCard {
         val fixture = byteArrayOf(
             0x70, 0x3D,

--- a/composeApp/src/androidUnitTest/kotlin/io/github/a7asoft/ui/ReaderViewModelTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/io/github/a7asoft/ui/ReaderViewModelTest.kt
@@ -1,0 +1,135 @@
+package io.github.a7asoft.ui
+
+import io.github.a7asoft.nfc.NfcAvailabilityStatus
+import io.github.a7asoft.nfcemv.brand.Aid
+import io.github.a7asoft.nfcemv.extract.EmvCard
+import io.github.a7asoft.nfcemv.extract.EmvParser
+import io.github.a7asoft.nfcemv.reader.ReaderError
+import io.github.a7asoft.nfcemv.reader.ReaderState
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ReaderViewModelTest {
+
+    @BeforeTest
+    fun setMain() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+    }
+
+    @AfterTest
+    fun resetMain() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `initial state is NfcUnavailable when adapter is missing`() {
+        val vm = vm(NfcAvailabilityStatus.Unavailable)
+        assertEquals(ReaderUiState.NfcUnavailable, vm.state.value)
+    }
+
+    @Test
+    fun `initial state is NfcDisabled when adapter is off`() {
+        val vm = vm(NfcAvailabilityStatus.Disabled)
+        assertEquals(ReaderUiState.NfcDisabled, vm.state.value)
+    }
+
+    @Test
+    fun `initial state is Idle when adapter is enabled`() {
+        val vm = vm(NfcAvailabilityStatus.Available)
+        assertEquals(ReaderUiState.Idle, vm.state.value)
+    }
+
+    @Test
+    fun `onReadRequested transitions through every reader state to Done`() = runTest {
+        val card = sampleCard()
+        val flow = flowOf<ReaderState>(
+            ReaderState.TagDetected,
+            ReaderState.SelectingPpse,
+            ReaderState.SelectingAid(aid = sampleAid()),
+            ReaderState.ReadingRecords,
+            ReaderState.Done(card),
+        )
+        val vm = ReaderViewModel(
+            nfcAvailability = FakeNfcAvailability(NfcAvailabilityStatus.Available),
+        )
+        vm.onReadRequested(ReaderHandle { flow })
+        val done = assertIs<ReaderUiState.Done>(vm.state.value)
+        assertEquals(card, done.card)
+    }
+
+    @Test
+    fun `onReadRequested surfaces Failed when reader emits Failed terminal`() = runTest {
+        val error = ReaderError.PpseUnsupported
+        val flow = flowOf<ReaderState>(ReaderState.TagDetected, ReaderState.Failed(error))
+        val vm = ReaderViewModel(
+            nfcAvailability = FakeNfcAvailability(NfcAvailabilityStatus.Available),
+        )
+        vm.onReadRequested(ReaderHandle { flow })
+        val failed = assertIs<ReaderUiState.Failed>(vm.state.value)
+        assertEquals(error, failed.error)
+    }
+
+    @Test
+    fun `onReadRequested is ignored when state is not Idle`() = runTest {
+        val vm = ReaderViewModel(
+            nfcAvailability = FakeNfcAvailability(NfcAvailabilityStatus.Disabled),
+        )
+        vm.onReadRequested(ReaderHandle { flowOf(ReaderState.Done(sampleCard())) })
+        assertEquals(ReaderUiState.NfcDisabled, vm.state.value)
+    }
+
+    @Test
+    fun `reset returns to Idle from Done`() = runTest {
+        val vm = ReaderViewModel(
+            nfcAvailability = FakeNfcAvailability(NfcAvailabilityStatus.Available),
+        )
+        vm.onReadRequested(ReaderHandle { flowOf(ReaderState.Done(sampleCard())) })
+        vm.reset()
+        assertEquals(ReaderUiState.Idle, vm.state.value)
+    }
+
+    @Test
+    fun `refreshNfcAvailability picks up adapter being enabled`() {
+        val availability = FakeNfcAvailability(NfcAvailabilityStatus.Disabled)
+        val vm = ReaderViewModel(nfcAvailability = availability)
+        availability.set(NfcAvailabilityStatus.Available)
+        vm.refreshNfcAvailability()
+        assertEquals(ReaderUiState.Idle, vm.state.value)
+    }
+
+    private fun vm(status: NfcAvailabilityStatus): ReaderViewModel = ReaderViewModel(
+        nfcAvailability = FakeNfcAvailability(status),
+    )
+
+    private fun sampleAid(): Aid = Aid.fromHex("A0000000031010")
+
+    // why: EmvCard's `internal` constructor cannot be invoked from this
+    // module's tests. We rebuild it by parsing the canonical Visa fixture
+    // bytes (verbatim copy of `:shared:commonTest:Fixtures.VISA_CLASSIC`).
+    // EmvParser.parseOrThrow is the supported construction path.
+    private fun sampleCard(): EmvCard {
+        val fixture = byteArrayOf(
+            0x70, 0x3D,
+            0x4F, 0x07, 0xA0.toByte(), 0x00, 0x00, 0x00, 0x03, 0x10, 0x10,
+            0x5A, 0x08, 0x41, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11,
+            0x5F, 0x24, 0x03, 0x28, 0x12, 0x31,
+            0x5F, 0x20, 0x09, 0x56, 0x49, 0x53, 0x41, 0x20, 0x54, 0x45, 0x53, 0x54,
+            0x50, 0x04, 0x56, 0x49, 0x53, 0x41,
+            0x57, 0x10,
+            0x41, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11,
+            0xD2.toByte(), 0x81.toByte(), 0x22, 0x01, 0x00, 0x00, 0x00, 0x00,
+        )
+        return EmvParser.parseOrThrow(listOf(fixture))
+    }
+}

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -29,7 +29,7 @@ kotlin {
 
     sourceSets {
         commonMain.dependencies {
-            implementation(libs.kotlinx.datetime)
+            api(libs.kotlinx.datetime)
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)


### PR DESCRIPTION
## Summary

- Wires `:android:reader`'s `ContactlessReader` into composeApp. APK testable against real contactless EMV cards (Visa / Mastercard / Amex).
- Manifest declares `android.permission.NFC` and `<uses-feature android:name="android.hardware.nfc" android:required="true" />`. Activity uses `android:configChanges` to avoid recreation race during rotation.
- `MainActivity` owns NfcAdapter foreground reader-mode lifecycle (enable in `onResume`, disable in `onPause`); reader callback delegates each detected `Tag` to the ViewModel via a `ReaderHandle` adapter.
- `ReaderViewModel` is a plain `ViewModel` with injected `NfcAvailability` interface and a `ReaderHandle` per read - fully unit-testable without Robolectric.
- `ReaderUiState` sealed catalogue; `ReaderScreen` Compose screen renders each state from a single source of truth via hoisted callbacks.
- Subcomponents: `StatusHeader` (header + NFC settings CTA), `ReadingProgress` (linear indicator + stage label), `CardSummary` (masked PAN, brand displayName, expiry, cardholder, label, AID - uses `Pan.toString()` masking, NEVER `unmasked()`), `ErrorPanel` (friendly message + collapsible diagnostic + Try Again).
- 8 ViewModel unit tests cover initial-state branches (NfcUnavailable / NfcDisabled / Idle), happy-path mapping (every ReaderState -> ReaderUiState), Failed terminal, ignore-when-not-Idle guard, reset, and refreshNfcAvailability.
- ZERO `Log.*` / `println` anywhere in composeApp source. ZERO `pan.unmasked()` calls in UI code.
- Module boundary verified per CLAUDE.md §7: composeApp depends on `:shared` + `:android:reader` + Compose. Nothing depends on composeApp.

## ABI gate

`:shared:checkKotlinAbi` UNCHANGED. This PR consumes both libraries' public surfaces; modifies neither.

## Manual QA checklist (post-merge - operator runs on device)

- [ ] APK installs and launches.
- [ ] Tap Visa / Mastercard / Amex contactless -> state transitions visible; PAN masked; fields correct.
- [ ] Pull card mid-read -> `Failed(IoFailure(TagLost))` -> friendly message.
- [ ] PSE-only card -> `Failed(PpseUnsupported)` -> friendly message.
- [ ] NFC disabled -> "Open NFC settings" CTA works.
- [ ] No NFC hardware -> "NFC not supported" message; app does not crash.
- [ ] `adb logcat | grep -iE "4111|5500|3782"` empty - no PAN bytes ever logged.

## Test plan

- [x] `./gradlew :composeApp:assembleDebug` green.
- [x] `./gradlew :composeApp:testDebugUnitTest` - 8 new tests pass.
- [x] `./gradlew :shared:checkKotlinAbi ktlintCheck detekt` green.
- [x] Plan files (`docs/superpowers/plans/`) untracked.
- [x] No `Log.*` / `println` in composeApp source.

Closes #55.