### PR TITLE
docs: stamp v0.3.0 release date + bump README status badge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented here. The format follows 
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-04-30
+
 ### Changed — Real-card support: GPO inline TLV + Track 2 fallbacks + TTQ default (#59)
 Architectural fix for Visa qVSDC kernel-3 cards (Chase Credit + Debit observed). Captured the real-card APDU traffic via diagnostic logging and corrected the model of what `EmvParser` parses.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
     Native Android (Kotlin) + iOS (Swift) · KMP-shared parser          │
 │                                                                      │
 +   ❯ status                                                           │
-    [WIP] v0.1.0 in development · API not stable yet                   │
+    v0.3.0 · real-card support shipped · pre-1.0 (API may break)       │
 │                                                                      │
 +   ❯ license                                                          │
     Apache 2.0                                                         │
@@ -30,7 +30,7 @@
   <img src="https://img.shields.io/badge/Swift-F05138?style=flat-square&logo=swift&logoColor=white" />
   <img src="https://img.shields.io/badge/KMP-7F52FF?style=flat-square&logo=kotlin&logoColor=white" />
   <img src="https://img.shields.io/badge/License-Apache_2.0-blue?style=flat-square" />
-  <img src="https://img.shields.io/badge/Status-WIP-orange?style=flat-square" />
+  <img src="https://img.shields.io/badge/Release-v0.3.0-blue?style=flat-square" />
 </p>
 
 ---


### PR DESCRIPTION
Post-release docs hygiene after PR #63 / tag v0.3.0:

- CHANGELOG: convert `## [Unreleased]` (which carried v0.3.0 content) → `## [0.3.0] - 2026-04-30`. Fresh empty `[Unreleased]` block above for v0.3.x work.
- README: status line `[WIP] v0.1.0 in development` → `v0.3.0 · real-card support shipped · pre-1.0`. Status badge `WIP` → `v0.3.0`.

Doc-only. No code or test changes.