### PR TITLE
chore(iosApp): wire iosAppTests target + fix iOS PAN masking via EmvCard.maskedPan (#67 #68)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented here. The format follows 
 
 ## [Unreleased]
 
+### Fixed — iOS PAN masking via `EmvCard.maskedPan` getter (#68)
+- Added `EmvCard.maskedPan: String` to `:shared/commonMain`. Kotlin/Native unboxes `Pan` (`@JvmInline value class<String>`) through the ObjC bridge to a plain `NSString` carrying the raw PAN — `String(describing: card.pan)` from Swift bypasses `Pan.toString()`'s masking. The new getter exposes the masked form as a regular `String` that survives the bridge. Surfaced by the iOS test target wiring (#67) which added a regression test that pins the masked-PAN contract end-to-end.
+- iOS `EmvCardSummary.from(_ card:)` now uses `card.maskedPan` instead of `String(describing: card.pan)`. Android composeApp `CardSummary` adopts `card.maskedPan` for parity (Kotlin call sites box the value class correctly so the Android display already masked, but the consolidated getter is the new single-source-of-truth).
+- ABI delta: additive `EmvCard.maskedPan` getter.
+
+### Added — iosAppTests Xcode test target (#67)
+- The `iosAppTests/` Swift sources from PR #66 are now wired into a `PBXNativeTarget` of type `com.apple.product-type.bundle.unit-test`. `xcodebuild test` runs the suite (21 tests including the PCI-safety regression that surfaced #68).
+
 ### Added — iOS sample app integration (#65)
 - `iosApp/` now ships a working SwiftUI sample app that drives the `EmvReader` Swift package end-to-end. Mirror of the Android composeApp integration (#55). The previous KMP wizard scaffold (`Image(systemName: "swift")` placeholder) is replaced with a `ReaderScreen` that walks through PPSE → SELECT AID → GPO → READ RECORD and renders the parsed `EmvCard` via a PCI-safe `EmvCardSummary` projection.
 - New `ReaderViewModel: ObservableObject` (main-actor) decouples NFC session lifecycle from the SwiftUI view tree. Dependencies are injected via initialiser closures (`NfcAvailability` protocol + `() -> AsyncStream<ReaderState>` factory), making the type unit-testable without a simulator. The factory closure is the entire reader-stream abstraction — `EmvReader` already owns the `NFCTagReaderSession` lifecycle internally, so iosApp does not re-wrap it.

--- a/composeApp/src/androidMain/kotlin/io/github/a7asoft/ui/components/CardSummary.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/a7asoft/ui/components/CardSummary.kt
@@ -15,7 +15,9 @@ import io.github.a7asoft.nfcemv.extract.EmvCard
 
 /**
  * Renders an [EmvCard] using only its safe accessors:
- * - `pan.toString()` (always masked per [io.github.a7asoft.nfcemv.extract.Pan]).
+ * - `maskedPan` (always masked per [io.github.a7asoft.nfcemv.extract.Pan];
+ *   shared single-source-of-truth getter that also survives the iOS
+ *   ObjC bridge — see #68).
  * - `brand.displayName` (human-readable label per
  *   [io.github.a7asoft.nfcemv.brand.EmvBrand]).
  * - `expiry`, `cardholderName?`, `applicationLabel?`, `aid` — non-PCI
@@ -31,7 +33,7 @@ public fun CardSummary(card: EmvCard, onTryAgain: () -> Unit) {
             modifier = Modifier.padding(16.dp),
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-            Field(label = "PAN", value = card.pan.toString())
+            Field(label = "PAN", value = card.maskedPan)
             Field(label = "Brand", value = card.brand.displayName)
             Field(label = "Expiry", value = card.expiry.toString())
             Field(label = "Cardholder", value = card.cardholderName ?: "<not provided>")

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -11,8 +11,20 @@
 		A1000003000000000000001A /* CoreNFC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A1000004000000000000001A /* CoreNFC.framework */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		3AE3C9D92FA550D4007A52A1 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 2E4C1D6708399E1A142112EB /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 02299AFB72A83326979814C7;
+			remoteInfo = iosApp;
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXFileReference section */
-		313C0C769EE74C800152810B /* nfc-emv-toolkit.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = nfc-emv-toolkit.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		313C0C769EE74C800152810B /* nfc-emv-toolkit.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "nfc-emv-toolkit.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		3AE3C9D52FA550D4007A52A1 /* iosAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = iosAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		3AE3C9E22FA5516E007A52A1 /* iosApp.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = iosApp.xctestplan; sourceTree = "<group>"; };
 		A1000004000000000000001A /* CoreNFC.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreNFC.framework; path = System/Library/Frameworks/CoreNFC.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
@@ -21,13 +33,17 @@
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Info.plist,
-				iosApp.entitlements,
 			);
 			target = 02299AFB72A83326979814C7 /* iosApp */;
 		};
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
+		3AE3C9D62FA550D4007A52A1 /* iosAppTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = iosAppTests;
+			sourceTree = "<group>";
+		};
 		6B7D797CA337013775A75786 /* iosApp */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
@@ -44,6 +60,13 @@
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		3AE3C9D22FA550D4007A52A1 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		58F4AB201B4740B89D4D0C28 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -59,8 +82,10 @@
 		565CDC43C2D221EA8253BF50 = {
 			isa = PBXGroup;
 			children = (
+				3AE3C9E22FA5516E007A52A1 /* iosApp.xctestplan */,
 				EA82FED7927292D91E67EA86 /* Configuration */,
 				6B7D797CA337013775A75786 /* iosApp */,
+				3AE3C9D62FA550D4007A52A1 /* iosAppTests */,
 				A1000005000000000000001A /* Frameworks */,
 				A831433556833D0C3D992EAE /* Products */,
 			);
@@ -78,6 +103,7 @@
 			isa = PBXGroup;
 			children = (
 				313C0C769EE74C800152810B /* nfc-emv-toolkit.app */,
+				3AE3C9D52FA550D4007A52A1 /* iosAppTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -109,6 +135,29 @@
 			productReference = 313C0C769EE74C800152810B /* nfc-emv-toolkit.app */;
 			productType = "com.apple.product-type.application";
 		};
+		3AE3C9D42FA550D4007A52A1 /* iosAppTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3AE3C9DD2FA550D4007A52A1 /* Build configuration list for PBXNativeTarget "iosAppTests" */;
+			buildPhases = (
+				3AE3C9D12FA550D4007A52A1 /* Sources */,
+				3AE3C9D22FA550D4007A52A1 /* Frameworks */,
+				3AE3C9D32FA550D4007A52A1 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				3AE3C9DA2FA550D4007A52A1 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				3AE3C9D62FA550D4007A52A1 /* iosAppTests */,
+			);
+			name = iosAppTests;
+			packageProductDependencies = (
+			);
+			productName = iosAppTests;
+			productReference = 3AE3C9D52FA550D4007A52A1 /* iosAppTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -116,11 +165,15 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1620;
+				LastSwiftUpdateCheck = 2640;
 				LastUpgradeCheck = 1620;
 				TargetAttributes = {
 					02299AFB72A83326979814C7 = {
 						CreatedOnToolsVersion = 16.2;
+					};
+					3AE3C9D42FA550D4007A52A1 = {
+						CreatedOnToolsVersion = 26.4.1;
+						TestTargetID = 02299AFB72A83326979814C7;
 					};
 				};
 			};
@@ -142,12 +195,20 @@
 			projectRoot = "";
 			targets = (
 				02299AFB72A83326979814C7 /* iosApp */,
+				3AE3C9D42FA550D4007A52A1 /* iosAppTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
 		2135E077C55F1FD9D502A8DC /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3AE3C9D32FA550D4007A52A1 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -179,6 +240,13 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		3AE3C9D12FA550D4007A52A1 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C0657FB4F3C7FAC1FAA526D9 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -188,7 +256,146 @@
 		};
 /* End PBXSourcesBuildPhase section */
 
+/* Begin PBXTargetDependency section */
+		3AE3C9DA2FA550D4007A52A1 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 02299AFB72A83326979814C7 /* iosApp */;
+			targetProxy = 3AE3C9D92FA550D4007A52A1 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
 /* Begin XCBuildConfiguration section */
+		146CA879DA432F24A35DB7DE /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = arm64;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = iosApp/iosApp.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
+				DEVELOPMENT_TEAM = "${TEAM_ID}";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = iosApp/Info.plist;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		3AE3C9DB2FA550D4007A52A1 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.4;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.orbitlytech.iosAppTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/nfc-emv-toolkit.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/nfc-emv-toolkit";
+			};
+			name = Debug;
+		};
+		3AE3C9DC2FA550D4007A52A1 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.4;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.orbitlytech.iosAppTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/nfc-emv-toolkit.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/nfc-emv-toolkit";
+			};
+			name = Release;
+		};
+		61087B7870B0A5C5844B0C5B /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReferenceAnchor = EA82FED7927292D91E67EA86 /* Configuration */;
+			baseConfigurationReferenceRelativePath = Config.xcconfig;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.2;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
 		684606FC5625E17996734A7D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReferenceAnchor = EA82FED7927292D91E67EA86 /* Configuration */;
@@ -254,64 +461,6 @@
 			};
 			name = Debug;
 		};
-		61087B7870B0A5C5844B0C5B /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReferenceAnchor = EA82FED7927292D91E67EA86 /* Configuration */;
-			baseConfigurationReferenceRelativePath = Config.xcconfig;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
-				CLANG_ANALYZER_NONNULL = YES;
-				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_ENABLE_OBJC_WEAK = YES;
-				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_COMMA = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INFINITE_RECURSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
-				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-				CLANG_WARN_STRICT_PROTOTYPES = YES;
-				CLANG_WARN_SUSPICIOUS_MOVE = YES;
-				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = NO;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				ENABLE_NS_ASSERTIONS = NO;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				ENABLE_USER_SCRIPT_SANDBOXING = NO;
-				GCC_C_LANGUAGE_STANDARD = gnu17;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 18.2;
-				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				MTL_FAST_MATH = YES;
-				SDKROOT = iphoneos;
-				SWIFT_COMPILATION_MODE = wholemodule;
-				VALIDATE_PRODUCT = YES;
-			};
-			name = Release;
-		};
 		E2284D05942CF78CBEA9FBEA /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -341,43 +490,14 @@
 			};
 			name = Debug;
 		};
-		146CA879DA432F24A35DB7DE /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = arm64;
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_ENTITLEMENTS = iosApp/iosApp.entitlements;
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
-				DEVELOPMENT_TEAM = "${TEAM_ID}";
-				ENABLE_PREVIEWS = YES;
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_FILE = iosApp/Info.plist;
-				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
-				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-				);
-				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = Release;
-		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		E7CD0606DC0F444A1E458973 /* Build configuration list for PBXProject "iosApp" */ = {
+		3AE3C9DD2FA550D4007A52A1 /* Build configuration list for PBXNativeTarget "iosAppTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				684606FC5625E17996734A7D /* Debug */,
-				61087B7870B0A5C5844B0C5B /* Release */,
+				3AE3C9DB2FA550D4007A52A1 /* Debug */,
+				3AE3C9DC2FA550D4007A52A1 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -387,6 +507,15 @@
 			buildConfigurations = (
 				E2284D05942CF78CBEA9FBEA /* Debug */,
 				146CA879DA432F24A35DB7DE /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E7CD0606DC0F444A1E458973 /* Build configuration list for PBXProject "iosApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				684606FC5625E17996734A7D /* Debug */,
+				61087B7870B0A5C5844B0C5B /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/iosApp/iosApp.xcodeproj/xcshareddata/xcschemes/iosApp.xcscheme
+++ b/iosApp/iosApp.xcodeproj/xcshareddata/xcschemes/iosApp.xcscheme
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2640"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "02299AFB72A83326979814C7"
+               BuildableName = "nfc-emv-toolkit.app"
+               BlueprintName = "iosApp"
+               ReferencedContainer = "container:iosApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:iosApp.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3AE3C9D42FA550D4007A52A1"
+               BuildableName = "iosAppTests.xctest"
+               BlueprintName = "iosAppTests"
+               ReferencedContainer = "container:iosApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      queueDebuggingEnableBacktraceRecording = "Yes">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "02299AFB72A83326979814C7"
+            BuildableName = "nfc-emv-toolkit.app"
+            BlueprintName = "iosApp"
+            ReferencedContainer = "container:iosApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "02299AFB72A83326979814C7"
+            BuildableName = "nfc-emv-toolkit.app"
+            BlueprintName = "iosApp"
+            ReferencedContainer = "container:iosApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/iosApp/iosApp.xctestplan
+++ b/iosApp/iosApp.xctestplan
@@ -1,0 +1,30 @@
+{
+  "configurations" : [
+    {
+      "id" : "444F26C4-6F5F-4F6C-9505-7116D7969E62",
+      "name" : "Test Scheme Action",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "performanceAntipatternCheckerEnabled" : true,
+    "targetForVariableExpansion" : {
+      "containerPath" : "container:iosApp.xcodeproj",
+      "identifier" : "02299AFB72A83326979814C7",
+      "name" : "iosApp"
+    }
+  },
+  "testTargets" : [
+    {
+      "parallelizable" : true,
+      "target" : {
+        "containerPath" : "container:iosApp.xcodeproj",
+        "identifier" : "3AE3C9D42FA550D4007A52A1",
+        "name" : "iosAppTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/iosApp/iosApp/ui/ReaderUiState.swift
+++ b/iosApp/iosApp/ui/ReaderUiState.swift
@@ -47,15 +47,22 @@ public enum ReaderUiState: @unchecked Sendable {
 /// PCI-safe display projection of ``Shared/EmvCard``.
 ///
 /// Stores already-stringified fields so the UI never has access to the
-/// unmasked PAN. The `pan` field carries the result of
-/// `String(describing:)` on the Kotlin `Pan` value class — that
-/// `toString()` masks per PCI DSS Req 3.4 (first-6 + last-4).
+/// unmasked PAN. The `pan` field carries `EmvCard.maskedPan` — a
+/// regular Kotlin `String` getter that calls `Pan.toString()` on the
+/// Kotlin side (where the `@JvmInline value class` boxes correctly)
+/// and exposes the PCI DSS Req 3.4 first-6 + last-4 mask intact across
+/// the ObjC bridge (issue #68).
+///
+/// `String(describing: card.pan)` MUST NOT be used: Kotlin/Native
+/// unboxes `Pan` through the ObjC bridge to a plain `NSString` carrying
+/// the raw PAN, bypassing the masking contract.
 ///
 /// NEVER call `card.pan.unmasked()` when constructing a summary — the
 /// sample app explicitly does not show raw PAN even with the card in
 /// hand (mirrors the Android `CardSummary` discipline).
 public struct EmvCardSummary: Equatable {
-    /// Masked PAN string from the Kotlin `Pan.toString()`.
+    /// Masked PAN string from `EmvCard.maskedPan` (Kotlin-side
+    /// `Pan.toString()` proxy that survives the ObjC bridge).
     public let pan: String
     /// Brand display name (e.g. "Visa", "Mastercard", "Unknown").
     public let brand: String
@@ -76,12 +83,14 @@ public struct EmvCardSummary: Equatable {
 extension EmvCardSummary {
     /// Build a summary from the bridged Kotlin ``Shared/EmvCard``.
     ///
-    /// All field accesses go through the Kotlin `description` (i.e.
-    /// `toString()`) because that path is the one with the masking
-    /// contract baked in.
+    /// `pan` is read via `card.maskedPan`, a Kotlin-side `String`
+    /// getter that proxies `Pan.toString()` so the masking contract
+    /// survives the ObjC bridge (#68). Other PAN-bearing fields go
+    /// through the Kotlin `description` (`toString()`) which has
+    /// masking baked in.
     public static func from(_ card: EmvCard) -> EmvCardSummary {
         return EmvCardSummary(
-            pan: String(describing: card.pan),
+            pan: card.maskedPan,
             brand: card.brand.displayName,
             expiry: String(describing: card.expiry),
             cardholderName: card.cardholderName,

--- a/shared/api/android/shared.api
+++ b/shared/api/android/shared.api
@@ -255,6 +255,7 @@ public final class io/github/a7asoft/nfcemv/extract/EmvCard {
 	public final fun getBrand ()Lio/github/a7asoft/nfcemv/brand/EmvBrand;
 	public final fun getCardholderName ()Ljava/lang/String;
 	public final fun getExpiry ()Lkotlinx/datetime/YearMonth;
+	public final fun getMaskedPan ()Ljava/lang/String;
 	public final fun getPan-o5U9eh4 ()Ljava/lang/String;
 	public final fun getTrack2 ()Lio/github/a7asoft/nfcemv/extract/Track2;
 	public fun hashCode ()I

--- a/shared/api/shared.klib.api
+++ b/shared/api/shared.klib.api
@@ -1167,6 +1167,8 @@ final class io.github.a7asoft.nfcemv.extract/EmvCard { // io.github.a7asoft.nfce
         final fun <get-cardholderName>(): kotlin/String? // io.github.a7asoft.nfcemv.extract/EmvCard.cardholderName.<get-cardholderName>|<get-cardholderName>(){}[0]
     final val expiry // io.github.a7asoft.nfcemv.extract/EmvCard.expiry|{}expiry[0]
         final fun <get-expiry>(): kotlinx.datetime/YearMonth // io.github.a7asoft.nfcemv.extract/EmvCard.expiry.<get-expiry>|<get-expiry>(){}[0]
+    final val maskedPan // io.github.a7asoft.nfcemv.extract/EmvCard.maskedPan|{}maskedPan[0]
+        final fun <get-maskedPan>(): kotlin/String // io.github.a7asoft.nfcemv.extract/EmvCard.maskedPan.<get-maskedPan>|<get-maskedPan>(){}[0]
     final val pan // io.github.a7asoft.nfcemv.extract/EmvCard.pan|{}pan[0]
         final fun <get-pan>(): io.github.a7asoft.nfcemv.extract/Pan // io.github.a7asoft.nfcemv.extract/EmvCard.pan.<get-pan>|<get-pan>(){}[0]
     final val track2 // io.github.a7asoft.nfcemv.extract/EmvCard.track2|{}track2[0]

--- a/shared/src/commonMain/kotlin/io/github/a7asoft/nfcemv/extract/EmvCard.kt
+++ b/shared/src/commonMain/kotlin/io/github/a7asoft/nfcemv/extract/EmvCard.kt
@@ -43,6 +43,22 @@ public data class EmvCard internal constructor(
     public val track2: Track2?,
     public val aid: Aid,
 ) {
+    /**
+     * PCI-DSS-compliant masked PAN — first 6 (BIN) + asterisks + last 4.
+     *
+     * **Why this exists:** Kotlin/Native's ObjC bridge unboxes
+     * [Pan] (a `@JvmInline value class<String>`) to a plain `NSString`
+     * carrying the raw PAN. Swift code calling `String(describing:
+     * card.pan)` would receive the raw PAN, bypassing [Pan]'s
+     * `toString()` masking. This getter exposes the masked form as a
+     * regular [String] that survives the ObjC bridge intact (issue #68).
+     *
+     * Kotlin call sites should prefer `pan.toString()` directly — the
+     * value class boxes correctly when `toString` is called on a
+     * Kotlin reference.
+     */
+    public val maskedPan: String get() = pan.toString()
+
     override fun toString(): String =
         "EmvCard(pan=$pan, expiry=$expiry, cardholderName=${maskCardholderName(cardholderName)}, " +
             "brand=$brand, applicationLabel=$applicationLabel, track2=$track2, aid=$aid)"


### PR DESCRIPTION
Closes #67 and #68.

## Summary

Bundled because #67 (test target wiring) surfaced #68 (iOS PAN masking PCI bug).

### #67 — iosAppTests Xcode test target

The Swift test sources committed in PR #66 are now wired into a `PBXNativeTarget` of type `com.apple.product-type.bundle.unit-test` via Xcode UI generation. \`xcodebuild test\` runs the suite — **21 tests pass**.

Includes the wizard-generated shared scheme + xctestplan so the test target is invokable on fresh clones / CI.

### #68 — iOS PAN masking PCI fix

The newly-wired test \`testEmvCardSummaryPanIsMaskedNeverRaw\` revealed that Kotlin/Native unboxes \`@JvmInline value class Pan(private val raw: String)\` through the ObjC bridge to a plain \`NSString\` carrying the raw PAN. Swift code calling \`String(describing: card.pan)\` was bypassing \`Pan.toString()\`'s masking — surfacing raw PAN in the iOS UI. The auto-generated \`Shared.h\` header acknowledges this caveat in its docstring.

**Fix:** new \`EmvCard.maskedPan: String\` getter in \`:shared/commonMain\` that calls \`pan.toString()\` from Kotlin's side (where the value class boxes correctly). The getter returns a regular \`String\` which the ObjC bridge exposes as \`NSString\` carrying the masked form intact.

- iOS \`EmvCardSummary.from\` switched from \`String(describing: card.pan)\` to \`card.maskedPan\`.
- Android composeApp \`CardSummary\` adopts \`card.maskedPan\` for cross-platform parity (Kotlin call sites already mask correctly via value-class boxing, so no behavioral change on Android — just consolidates the source of truth).

ABI delta: additive \`EmvCard.maskedPan\` getter only.

## Gates

- \`xcodebuild test\` (iPhone 17 Pro) — **21/21 tests pass** including the previously-failing PCI regression test.
- \`:shared:checkKotlinAbi\` — additive only (\`EmvCard.maskedPan\`).
- \`:shared:ktlintCheck :detekt :allTests\` ✅
- \`:android:reader:testDebugUnitTest\` ✅
- \`:composeApp:compileDebugKotlinAndroid\` ✅