### PR TITLE
fix(iosApp): expand NFC select-identifiers with EMV application AIDs

### DIFF
--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -8,7 +8,32 @@
 	<string>Read contactless EMV card data via NFC for parsing and display. The app does not transmit, store, or authorize transactions.</string>
 	<key>com.apple.developer.nfc.readersession.iso7816.select-identifiers</key>
 	<array>
+		<!-- PPSE 2PAY.SYS.DDF01 — EMV directory file -->
 		<string>325041592E5359532E4444463031</string>
+		<!-- Visa (Credit/Debit, Electron, V Pay) -->
+		<string>A0000000031010</string>
+		<string>A0000000032010</string>
+		<string>A0000000032020</string>
+		<!-- Mastercard (Credit/Debit, Maestro, World) -->
+		<string>A0000000041010</string>
+		<string>A0000000042010</string>
+		<string>A0000000043060</string>
+		<!-- American Express (ExpressPay, Centurion) -->
+		<string>A00000002501</string>
+		<string>A000000025010402</string>
+		<string>A000000025010701</string>
+		<string>A000000025010801</string>
+		<!-- Discover / Diners Club International -->
+		<string>A0000001523010</string>
+		<string>A0000003241010</string>
+		<!-- JCB -->
+		<string>A0000000651010</string>
+		<!-- UnionPay -->
+		<string>A000000333010101</string>
+		<string>A000000333010102</string>
+		<string>A000000333010103</string>
+		<!-- Interac -->
+		<string>A0000002771010</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
## Problem

Real-device QA on iPhone with paid Apple Developer account: app installs, "Tap a card" button presents NFCTagReaderSession, system sheet "Ready to Scan" appears. **No card is ever detected** — \`didDetect\` callback never fires regardless of physical position, card brand, duration of contact.

## Root cause

iOS \`NFCTagReaderSession\` filters tags via Info.plist \`com.apple.developer.nfc.readersession.iso7816.select-identifiers\` BEFORE notifying the app. Per Apple docs:
> The system uses the list to filter the tags it presents to your app. iPhone will only call \`tagReaderSession(_:didDetect:)\` for tags that contain at least one of the listed AIDs.

PR #66 listed only the PPSE AID (\`325041592E5359532E4444463031\` = \`2PAY.SYS.DDF01\`). PPSE is a directory file, not an EMV application AID. iOS does NOT match the PPSE alone — it requires actual application AIDs (Visa \`A0000000031010\`, Mastercard \`A0000000041010\`, etc.). With only PPSE listed, iOS silently filters every contactless EMV card out → \`didDetect\` never called → user sees the sheet hang indefinitely.

## Fix

Adds the standard contactless application AIDs covered by the toolkit's \`BrandResolver\`:

- Visa (Credit/Debit, Electron, V Pay) — \`A0000000031010\`, \`A0000000032010\`, \`A0000000032020\`
- Mastercard (Credit/Debit, Maestro, World) — \`A0000000041010\`, \`A0000000042010\`, \`A0000000043060\`
- American Express (Centurion, ExpressPay) — \`A00000002501\`, \`A000000025010402\`, \`A000000025010701\`, \`A000000025010801\`
- Discover / Diners Club International — \`A0000001523010\`, \`A0000003241010\`
- JCB — \`A0000000651010\`
- UnionPay — \`A000000333010101\`/\`02\`/\`03\`
- Interac — \`A0000002771010\`

PPSE retained for explicit directory file lookup.

## What this fix closes

Resolves the \`[AMBIGUOUS]\` finding from PR #66 ios-swift-reviewer:
> "Apple's \`com.apple.developer.nfc.readersession.iso7816.select-identifiers\` documentation states all AIDs that the app will SELECT must be listed. EmvReader selects application AIDs (e.g., Visa A0000000031010) after PPSE — these are not listed. Whether iOS 14+ enforces this for secondary SELECT commands (post-PPSE discovery) or only for the initial SELECT is not definitively documented as of this review."

**Empirical answer (this PR):** iOS enforces \`select-identifiers\` for the INITIAL tag detection — not just secondary SELECTs. Without app AIDs listed, no tag is presented to the app at all.

## Out of scope

- Adding country-specific debit AIDs (Interac sub-AIDs, etc.). Library's \`BrandResolver\` doesn't enumerate these yet either.
- Per-card-brand entitlement gating from Apple — some AIDs may require additional entitlement (not the case for the brands listed here per current Apple docs).

## Acceptance

- [ ] Manual real-device QA: tap each of the 5 cards (MC SoFi credit/debit, Discover, Visa Credit/Debit Chase) → \`didDetect\` fires → \`Done(card)\` UI rendered with masked PAN.